### PR TITLE
ignore mkdir EEXIST error

### DIFF
--- a/src/lib/fsCache/cache.js
+++ b/src/lib/fsCache/cache.js
@@ -94,7 +94,7 @@ module.exports = class fsCache {
                 .then(() => {
                     let fullFileName = path.join(this._path, key);
                     fs.mkdir(path.dirname(fullFileName), { recursive: true }, (err) => {
-                        if (err) {
+                        if (err && (err.code !== 'EEXIST')) {
                             reject(errorMessage(errorCodes.WriteError, err.message));
                         }
                         else {

--- a/src/lib/fsCache/cache.js
+++ b/src/lib/fsCache/cache.js
@@ -94,6 +94,7 @@ module.exports = class fsCache {
                 .then(() => {
                     let fullFileName = path.join(this._path, key);
                     fs.mkdir(path.dirname(fullFileName), { recursive: true }, (err) => {
+                         // For some versions, mkdir throws EEXIST even if recursive:true is passed, which can be ignored here.
                         if (err && (err.code !== 'EEXIST')) {
                             reject(errorMessage(errorCodes.WriteError, err.message));
                         }

--- a/src/lib/fsCache/cache.js
+++ b/src/lib/fsCache/cache.js
@@ -94,7 +94,7 @@ module.exports = class fsCache {
                 .then(() => {
                     let fullFileName = path.join(this._path, key);
                     fs.mkdir(path.dirname(fullFileName), { recursive: true }, (err) => {
-                         // For some versions, mkdir throws EEXIST even if recursive:true is passed, which can be ignored here.
+                        // For some versions, mkdir throws EEXIST even if recursive:true is passed, which can be ignored here.
                         if (err && (err.code !== 'EEXIST')) {
                             reject(errorMessage(errorCodes.WriteError, err.message));
                         }


### PR DESCRIPTION
## Description

As per mkdir spec, mkdir shouldn't throw EEXIST if recursive:true option is provided. But it seems it fails for some specific version. So adding check to ignore this error if that happens.  

## Related issues

Addresses [issue #].

## Testing

Tested manually to a machine which reported the issue.
