### PR TITLE
Personal/yankun/handleDateFormat

### DIFF
--- a/src/lib/handlebars-converter/handlebars-helpers.js
+++ b/src/lib/handlebars-converter/handlebars-helpers.js
@@ -36,10 +36,11 @@ var getDate = function (dateTimeString) {
     var ds = dateTimeString.toString();
     if (!/^\d+$/.test(ds))
         return null;
-    if (0 <= ds.length <= 5 && ds.length == 7)
-        return ds;
     if (ds.length == 6)
         return ds.substring(0, 4) + '-' + ds.substring(4, 6);
+    if (ds.length <= 7)
+        return ds;
+    
     if (ds.length == 8)
         return ds.substring(0, 4) + '-' + ds.substring(4, 6) + '-' + ds.substring(6, 8);
 

--- a/src/lib/handlebars-converter/handlebars-helpers.js
+++ b/src/lib/handlebars-converter/handlebars-helpers.js
@@ -32,7 +32,15 @@ var normalizeSectionName = function (name) {
 };
 
 var getDate = function (dateTimeString) {
+    // handling the date format here
     var ds = dateTimeString.toString();
+    if (/^(\d{0,5}|\d{7})$/.test(ds))
+        return ds;
+    if (/^\d{6}$/.test(ds))
+        return ds.substring(0, 4) + '-' + ds.substring(4, 6);
+    if (/^\d{8}$/.test(ds))
+        return ds.substring(0, 4) + '-' + ds.substring(4, 6) + '-' + ds.substring(6, 8);
+
     ds = ds.padEnd(17, '0');
     var year = ds.slice(0, 4);
     var monthIndex = ds.slice(4, 6) - 1;
@@ -44,7 +52,7 @@ var getDate = function (dateTimeString) {
     var minute = ds.slice(10, 12);
     var second = ds.slice(12, 14);
     var millisecond = ds.slice(14, 17);
-    return (new Date(Date.UTC(year, monthIndex, day, hour, minute, second, millisecond)));
+    return (new Date(Date.UTC(year, monthIndex, day, hour, minute, second, millisecond))).toJSON();
 };
 
 module.exports.internal = {
@@ -660,13 +668,11 @@ module.exports.external = [
         func: function (date) {
             try {
                 var bd = date.toString();
-
-                // Should be 8 digits
-                if (!/^\d{8}$/.test(bd)) {
-                    return bd;
-                }
-
-                return bd.substring(0, 4) + '-' + bd.substring(4, 6) + '-' + bd.substring(6, 8);
+                if (/^\d{8,17}$/.test(bd)) 
+                    return bd.substring(0, 4) + '-' + bd.substring(4, 6) + '-' + bd.substring(6, 8);
+                if (/^\d{6}$/.test(bd))
+                    return bd.substring(0, 4) + '-' + bd.substring(4, 6);
+                return bd;
             }
             catch (err) {
                 return '';
@@ -685,7 +691,7 @@ module.exports.external = [
         description: 'Converts an YYYYMMDDHHmmssSSS string, e.g. 20040629175400000 to dateTime format, e.g. 2004-06-29T17:54:00.000z: formatAsDateTime(dateTimeString)',
         func: function (dateTimeString) {
             try {
-                return getDate(dateTimeString).toJSON();
+                return getDate(dateTimeString);
             }
             catch (err) {
                 return '';

--- a/src/lib/handlebars-converter/handlebars-helpers.js
+++ b/src/lib/handlebars-converter/handlebars-helpers.js
@@ -40,7 +40,6 @@ var getDate = function (dateTimeString) {
         return ds.substring(0, 4) + '-' + ds.substring(4, 6);
     if (ds.length <= 7)
         return ds;
-    
     if (ds.length == 8)
         return ds.substring(0, 4) + '-' + ds.substring(4, 6) + '-' + ds.substring(6, 8);
 

--- a/src/lib/handlebars-converter/handlebars-helpers.js
+++ b/src/lib/handlebars-converter/handlebars-helpers.js
@@ -34,11 +34,13 @@ var normalizeSectionName = function (name) {
 var getDate = function (dateTimeString) {
     // handling the date format here
     var ds = dateTimeString.toString();
-    if (/^(\d{0,5}|\d{7})$/.test(ds))
+    if (!/^\d+$/.test(ds))
+        return null;
+    if (0 <= ds.length <= 5 && ds.length == 7)
         return ds;
-    if (/^\d{6}$/.test(ds))
+    if (ds.length == 6)
         return ds.substring(0, 4) + '-' + ds.substring(4, 6);
-    if (/^\d{8}$/.test(ds))
+    if (ds.length == 8)
         return ds.substring(0, 4) + '-' + ds.substring(4, 6) + '-' + ds.substring(6, 8);
 
     ds = ds.padEnd(17, '0');
@@ -668,10 +670,12 @@ module.exports.external = [
         func: function (date) {
             try {
                 var bd = date.toString();
-                if (/^\d{8,17}$/.test(bd)) 
-                    return bd.substring(0, 4) + '-' + bd.substring(4, 6) + '-' + bd.substring(6, 8);
-                if (/^\d{6}$/.test(bd))
+                if (!/^\d+$/.test(bd))
+                    return null;
+                if (bd.length == 6)
                     return bd.substring(0, 4) + '-' + bd.substring(4, 6);
+                if (bd.length >= 8)
+                    return bd.substring(0, 4) + '-' + bd.substring(4, 6) + '-' + bd.substring(6, 8);
                 return bd;
             }
             catch (err) {

--- a/src/lib/handlebars-converter/handlebars-helpers.js
+++ b/src/lib/handlebars-converter/handlebars-helpers.js
@@ -135,7 +135,6 @@ var getDateTime = function (dateTimeString) {
         {
             var dateSections = ds.split(ds[14]);
             var dateTimeComposition = getDateTimeComposition(dateSections[0]);
-            dateTimeComposition.milliseconds = 0;
             var date = dateTimeComposition.year + '-' + dateTimeComposition.month + '-' + dateTimeComposition.day;
             var time = dateTimeComposition.hours + ':' + dateTimeComposition.minutes + ':' + dateTimeComposition.seconds;
             var timezone = ds[14] + dateSections[1];

--- a/src/lib/handlebars-converter/handlebars-helpers.js
+++ b/src/lib/handlebars-converter/handlebars-helpers.js
@@ -34,25 +34,27 @@ var normalizeSectionName = function (name) {
 // check the date is valid
 var validDate = function (year, monthIndex, day){
     var dateInstance = new Date(year, monthIndex, day);
-    if(dateInstance.getFullYear() == year && dateInstance.getMonth() == monthIndex && dateInstance.getDate() == day)
+    if(dateInstance.getFullYear() === Number(year) && dateInstance.getMonth() === Number(monthIndex) && dateInstance.getDate() === Number(day))
         return true;
     return false;
 };
 
 // check the datetime is valid
 var validUTCDateTime = function (dateTimeComposition){
+    for (var key in dateTimeComposition)
+        dateTimeComposition[key] = Number(dateTimeComposition[key]);
     var dateInstance = new Date(Date.UTC(dateTimeComposition.year, dateTimeComposition.month - 1, dateTimeComposition.day, dateTimeComposition.hours, dateTimeComposition.minutes, dateTimeComposition.seconds, dateTimeComposition.milliseconds));
-    if(dateInstance.getUTCFullYear() == dateTimeComposition.year && dateInstance.getUTCMonth() == dateTimeComposition.month - 1 
-        && dateInstance.getUTCDate() == dateTimeComposition.day && dateInstance.getUTCHours() == dateTimeComposition.hours 
-        && dateInstance.getUTCMinutes() == dateTimeComposition.minutes && dateInstance.getSeconds() == dateTimeComposition.seconds 
-        && dateInstance.getMilliseconds() == dateTimeComposition.milliseconds)
+    if(dateInstance.getUTCFullYear() === dateTimeComposition.year && dateInstance.getUTCMonth() === dateTimeComposition.month - 1 
+        && dateInstance.getUTCDate() === dateTimeComposition.day && dateInstance.getUTCHours() === dateTimeComposition.hours 
+        && dateInstance.getUTCMinutes() === dateTimeComposition.minutes && dateInstance.getSeconds() === dateTimeComposition.seconds 
+        && dateInstance.getMilliseconds() === dateTimeComposition.milliseconds)
         return true;
     return false;
 };
 
 // check the string is valid
 var validString = function (dateTimeString) {
-    if (!dateTimeString || dateTimeString.toString() == '')
+    if (!dateTimeString || dateTimeString.toString() === '')
         return false;
     return true;
 };
@@ -67,14 +69,14 @@ var validDigitString = function (dateTimeString) {
 
 // convert the dateString to date string with hyphens
 var convertDate = function (dateString) {
-    if (dateString.length == 4)
+    if (dateString.length === 4)
         return dateString;
-    if (dateString.length == 6 || dateString.length >= 8){
+    if (dateString.length === 6 || dateString.length >= 8){
         var year = dateString.substring(0, 4);
         var month = dateString.substring(4, 6);
         if (month <= 0 || month > 12)
             throw `Invalid month: ${dateString}`;
-        if (dateString.length == 6)
+        if (dateString.length === 6)
             return year + '-' + month;
         var day = dateString.substring(6, 8);
         if (!validDate(year, month - 1, day))
@@ -87,15 +89,10 @@ var convertDate = function (dateString) {
 
 // handling the date format here
 var getDate = function (dateString) {
-    try{
-        if (!validString(dateString))
-            return '';
-        var ds = validDigitString(dateString);
-        return convertDate(ds);
-    }
-    catch (err) {
-        throw `${err}`;
-    }
+    if (!validString(dateString))
+        return '';
+    var ds = validDigitString(dateString);
+    return convertDate(ds);
 };
 
 module.exports.internal = {
@@ -125,37 +122,32 @@ var getDateTimeComposition = function (ds){
 
 // handling the datetime format here
 var getDateTime = function (dateTimeString) {
-    try{
-        if (!validString(dateTimeString))
-            return '';
+    if (!validString(dateTimeString))
+        return '';
 
-        // handle special datetime format like 20130130080051+0500, 20130130080051-0500
-        var ds = dateTimeString.toString();
-        if (/^(\d{14})(-|\+)(\d{4})$/.test(ds))
-        {
-            var dateSections = ds.split(ds[14]);
-            var dateTimeComposition = getDateTimeComposition(dateSections[0]);
-            var date = dateTimeComposition.year + '-' + dateTimeComposition.month + '-' + dateTimeComposition.day;
-            var time = dateTimeComposition.hours + ':' + dateTimeComposition.minutes + ':' + dateTimeComposition.seconds;
-            var timezone = ds[14] + dateSections[1];
-            if (!validUTCDateTime(dateTimeComposition))
-                throw `Invalid datetime: ${ds}`;
-            return new Date(date + ' ' + time + ' ' + timezone).toISOString();
-        }
-
-        ds = validDigitString(dateTimeString);
-        if (ds.length <= 8)
-            return convertDate(ds);
-        
-        // Padding 0s to 17 digits 
-        dateTimeComposition = getDateTimeComposition(ds);
+    // handle special datetime format like 20130130080051+0500, 20130130080051-0500
+    var ds = dateTimeString.toString();
+    if (/^(\d{14})(-|\+)(\d{4})$/.test(ds))
+    {
+        var dateSections = ds.split(ds[14]);
+        var dateTimeComposition = getDateTimeComposition(dateSections[0]);
+        var date = dateTimeComposition.year + '-' + dateTimeComposition.month + '-' + dateTimeComposition.day;
+        var time = dateTimeComposition.hours + ':' + dateTimeComposition.minutes + ':' + dateTimeComposition.seconds;
+        var timezone = ds[14] + dateSections[1];
         if (!validUTCDateTime(dateTimeComposition))
             throw `Invalid datetime: ${ds}`;
-        return (new Date(Date.UTC(dateTimeComposition.year, dateTimeComposition.month - 1, dateTimeComposition.day, dateTimeComposition.hours, dateTimeComposition.minutes, dateTimeComposition.seconds, dateTimeComposition.milliseconds))).toJSON();
+        return new Date(date + ' ' + time + ' ' + timezone).toISOString();
     }
-    catch (err) {
-        throw `${err}`;
-    }
+
+    ds = validDigitString(dateTimeString);
+    if (ds.length <= 8)
+        return convertDate(ds);
+    
+    // Padding 0s to 17 digits 
+    dateTimeComposition = getDateTimeComposition(ds);
+    if (!validUTCDateTime(dateTimeComposition))
+        throw `Invalid datetime: ${ds}`;
+    return (new Date(Date.UTC(dateTimeComposition.year, dateTimeComposition.month - 1, dateTimeComposition.day, dateTimeComposition.hours, dateTimeComposition.minutes, dateTimeComposition.seconds, dateTimeComposition.milliseconds))).toJSON();
 };
 
 module.exports.internal = {

--- a/src/lib/handlebars-converter/handlebars-helpers.js
+++ b/src/lib/handlebars-converter/handlebars-helpers.js
@@ -95,10 +95,6 @@ var getDate = function (dateString) {
     return convertDate(ds);
 };
 
-module.exports.internal = {
-    getDate: getDate
-};
-
 var getDateTimeComposition = function (ds){
     ds = ds.padEnd(17, '0');
     var year = ds.substring(0,4);
@@ -151,7 +147,8 @@ var getDateTime = function (dateTimeString) {
 };
 
 module.exports.internal = {
-    getDateTime: getDateTime
+    getDateTime: getDateTime,
+    getDate: getDate
 };
 
 module.exports.external = [

--- a/src/lib/handlebars-converter/handlebars-helpers.spec.js
+++ b/src/lib/handlebars-converter/handlebars-helpers.spec.js
@@ -266,9 +266,13 @@ describe('Handlebars helpers', function () {
         assert.strictEqual('2001-01-02', getHelper('addHyphensDate').func('200101020000'));
     });
 
+    it('addHyphensDate return null when passed some non-numeric characters', function() {
+        assert.strictEqual(null, getHelper('addHyphensDate').func('2001test'));
+    });
+
     it('addHyphensDate leaves input unchanged when not 6, 8-17 digits', function() {
         assert.strictEqual('123', getHelper('addHyphensDate').func('123'));
-        assert.strictEqual('2001-01-', getHelper('addHyphensDate').func('2001-01-'));
+        assert.strictEqual('1999110', getHelper('addHyphensDate').func('1999110'));
     });
 
     it('getFirstCdaSections should return a dictionary with first instance of sections', function (done) {

--- a/src/lib/handlebars-converter/handlebars-helpers.spec.js
+++ b/src/lib/handlebars-converter/handlebars-helpers.spec.js
@@ -104,8 +104,11 @@ describe('Handlebars helpers', function () {
         { f: 'addHyphensSSN', in: [undefined], out: "" },
         { f: 'addHyphensDate', in: [undefined], out: "" },
         { f: 'formatAsDateTime', in: [undefined], out: "" },
+        {f: 'formatAsDateTime', in: ["2004"], out: "2004"}, // eslint-disable-line
+        {f: 'formatAsDateTime', in: ["20041"], out: "20041"}, // eslint-disable-line
+        {f: 'formatAsDateTime', in: ["200411"], out: "2004-11"}, // eslint-disable-line
+        {f: 'formatAsDateTime', in: ["20041101"], out: "2004-11-01"}, // eslint-disable-line
         { f: 'formatAsDateTime', in: ["2004062917540000"], out: (new Date(Date.UTC(2004, 05, 29, 17, 54)).toJSON()) }, // eslint-disable-line
-        { f: 'formatAsDateTime', in: ["2004"], out: (new Date(Date.UTC(2004, 00, 00, 00, 00)).toJSON()) }, // eslint-disable-line
         { f: 'formatAsDateTime', in: ["2004062917540034599999"], out: (new Date(Date.UTC(2004, 05, 29, 17, 54, 0, 345)).toJSON()) }, // eslint-disable-line
         { f: 'getFieldRepeats', in: [null], out: null },
         { f: 'toLower', in: ["ABCD"], out: "abcd" },
@@ -222,7 +225,7 @@ describe('Handlebars helpers', function () {
         var currentString = getHelper('now').func();
         var after = new Date();
 
-        var current = helperUtils.getDate(currentString);
+        var current = new Date(helperUtils.getDate(currentString));
 
         assert.ok(before <= current);
         assert.ok(current <= after);
@@ -253,13 +256,18 @@ describe('Handlebars helpers', function () {
         assert.strictEqual('123-45-67', getHelper('addHyphensSSN').func('123-45-67'));
     });
 
-    it('addHyphensDate adds hyphens when passed 8 digits', function () {
-        assert.strictEqual('2001-01-02', getHelper('addHyphensDate').func('20010102'));
+    it('addHyphensDate adds hyphens when passed 6 digits', function() {
+        assert.strictEqual('2001-01', getHelper('addHyphensDate').func('200101'));
     });
 
-    it('addHyphensDate leaves input unchanged when not 8 digits', function () {
+    it('addHyphensDate adds hyphens when passed 8-17 digits', function() {
+        assert.strictEqual('2001-01-02', getHelper('addHyphensDate').func('20010102'));
+        assert.strictEqual('2001-01-02', getHelper('addHyphensDate').func('2001010200'));
+        assert.strictEqual('2001-01-02', getHelper('addHyphensDate').func('200101020000'));
+    });
+
+    it('addHyphensDate leaves input unchanged when not 6, 8-17 digits', function() {
         assert.strictEqual('123', getHelper('addHyphensDate').func('123'));
-        assert.strictEqual('111111111111', getHelper('addHyphensDate').func('111111111111'));
         assert.strictEqual('2001-01-', getHelper('addHyphensDate').func('2001-01-'));
     });
 

--- a/src/lib/handlebars-converter/handlebars-helpers.spec.js
+++ b/src/lib/handlebars-converter/handlebars-helpers.spec.js
@@ -104,6 +104,7 @@ describe('Handlebars helpers', function () {
         { f: 'addHyphensSSN', in: [undefined], out: "" },
         { f: 'addHyphensDate', in: [undefined], out: "" },
         { f: 'formatAsDateTime', in: [undefined], out: "" },
+        {f: 'formatAsDateTime', in: ["20041wrong"], out: null}, // eslint-disable-line
         {f: 'formatAsDateTime', in: ["2004"], out: "2004"}, // eslint-disable-line
         {f: 'formatAsDateTime', in: ["20041"], out: "20041"}, // eslint-disable-line
         {f: 'formatAsDateTime', in: ["200411"], out: "2004-11"}, // eslint-disable-line

--- a/src/lib/handlebars-converter/handlebars-helpers.spec.js
+++ b/src/lib/handlebars-converter/handlebars-helpers.spec.js
@@ -104,11 +104,16 @@ describe('Handlebars helpers', function () {
         { f: 'addHyphensSSN', in: [undefined], out: "" },
         { f: 'addHyphensDate', in: [undefined], out: "" },
         { f: 'formatAsDateTime', in: [undefined], out: "" },
-        {f: 'formatAsDateTime', in: ["20041wrong"], out: null}, // eslint-disable-line
-        {f: 'formatAsDateTime', in: ["2004"], out: "2004"}, // eslint-disable-line
-        {f: 'formatAsDateTime', in: ["20041"], out: "20041"}, // eslint-disable-line
-        {f: 'formatAsDateTime', in: ["200411"], out: "2004-11"}, // eslint-disable-line
-        {f: 'formatAsDateTime', in: ["20041101"], out: "2004-11-01"}, // eslint-disable-line
+        { f: 'formatAsDateTime', in: ["2004"], out: "2004"}, 
+        { f: 'formatAsDateTime', in: ["200401"], out: "2004-01"}, 
+        { f: 'formatAsDateTime', in: ["200406"], out: "2004-06"}, 
+        { f: 'formatAsDateTime', in: ["200412"], out: "2004-12"}, 
+        { f: 'formatAsDateTime', in: ["20041101"], out: "2004-11-01"}, 
+        { f: 'formatAsDateTime', in: ["20041130"], out: "2004-11-30"}, 
+        { f: 'formatAsDateTime', in: ["20140130080051-0500"], out: (new Date(Date.UTC(2014, 0, 30, 13, 0, 51)).toJSON()) }, // eslint-disable-line
+        { f: 'formatAsDateTime', in: ["20140130080051+0500"], out: (new Date(Date.UTC(2014, 0, 30, 3, 0, 51)).toJSON()) }, // eslint-disable-line
+        { f: 'formatAsDateTime', in: ["20140130040051+0500"], out: (new Date(Date.UTC(2014, 0, 29, 23, 0, 51)).toJSON()) }, // eslint-disable-line
+        { f: 'formatAsDateTime', in: ["20140129230051-0500"], out: (new Date(Date.UTC(2014, 0, 30, 4, 0, 51)).toJSON()) }, // eslint-disable-line
         { f: 'formatAsDateTime', in: ["2004062917540000"], out: (new Date(Date.UTC(2004, 05, 29, 17, 54)).toJSON()) }, // eslint-disable-line
         { f: 'formatAsDateTime', in: ["2004062917540034599999"], out: (new Date(Date.UTC(2004, 05, 29, 17, 54, 0, 345)).toJSON()) }, // eslint-disable-line
         { f: 'getFieldRepeats', in: [null], out: null },
@@ -179,6 +184,24 @@ describe('Handlebars helpers', function () {
         { f: 'base64Decode', in: [undefined] },
         { f: 'escapeSpecialChars', in: [undefined] },
         { f: 'unescapeSpecialChars', in: [undefined] },
+        { f: 'formatAsDateTime', in: ["20badInput"]},  // bad input
+        { f: 'formatAsDateTime', in: ["2020-11"]},  // bad input
+        { f: 'formatAsDateTime', in: ["20140130080051--0500"]},  // bad input
+        { f: 'formatAsDateTime', in: ["20201"]},  // bad input
+        { f: 'formatAsDateTime', in: ["2020060"]},  // bad input
+        { f: 'formatAsDateTime', in: ["20201301"]}, // invalid month
+        { f: 'formatAsDateTime', in: ["20200134"]}, // invalid day
+        { f: 'formatAsDateTime', in: ["20200230"]}, // invalid day
+        { f: 'formatAsDateTime', in: ["2020010130"]},  // invalid hour
+        { f: 'formatAsDateTime', in: ["202001011080"]}, // invalid minutes
+        { f: 'formatAsDateTime', in: ["20200101101080"]}, // invalid seconds
+        { f: 'addHyphensDate', in: ["20badInput"]}, // bad input
+        { f: 'addHyphensDate', in: ["2020-11"]},  // bad input
+        { f: 'addHyphensDate', in: ["20201"]},  // bad input
+        { f: 'addHyphensDate', in: ["2020060"]},  // bad input
+        { f: 'addHyphensDate', in: ["20201301"]}, // invalid month
+        { f: 'addHyphensDate', in: ["20200134"]}, // invalid day
+        { f: 'addHyphensDate', in: ["20200230"]} // invalid day
     ];
 
     opErrorTests.forEach(t => {
@@ -226,7 +249,7 @@ describe('Handlebars helpers', function () {
         var currentString = getHelper('now').func();
         var after = new Date();
 
-        var current = new Date(helperUtils.getDate(currentString));
+        var current = new Date(helperUtils.getDateTime(currentString));
 
         assert.ok(before <= current);
         assert.ok(current <= after);
@@ -257,23 +280,22 @@ describe('Handlebars helpers', function () {
         assert.strictEqual('123-45-67', getHelper('addHyphensSSN').func('123-45-67'));
     });
 
+    it('addHyphensDate adds hyphens when passed 4 digits', function() {
+        assert.strictEqual('2001', getHelper('addHyphensDate').func('2001'));
+    });
+
     it('addHyphensDate adds hyphens when passed 6 digits', function() {
         assert.strictEqual('2001-01', getHelper('addHyphensDate').func('200101'));
+        assert.strictEqual('2001-06', getHelper('addHyphensDate').func('200106'));
+        assert.strictEqual('2001-12', getHelper('addHyphensDate').func('200112'));
     });
 
-    it('addHyphensDate adds hyphens when passed 8-17 digits', function() {
-        assert.strictEqual('2001-01-02', getHelper('addHyphensDate').func('20010102'));
-        assert.strictEqual('2001-01-02', getHelper('addHyphensDate').func('2001010200'));
-        assert.strictEqual('2001-01-02', getHelper('addHyphensDate').func('200101020000'));
-    });
-
-    it('addHyphensDate return null when passed some non-numeric characters', function() {
-        assert.strictEqual(null, getHelper('addHyphensDate').func('2001test'));
-    });
-
-    it('addHyphensDate leaves input unchanged when not 6, 8-17 digits', function() {
-        assert.strictEqual('123', getHelper('addHyphensDate').func('123'));
-        assert.strictEqual('1999110', getHelper('addHyphensDate').func('1999110'));
+    it('addHyphensDate adds hyphens when passed more than 8 digits', function() {
+        assert.strictEqual('2001-12-01', getHelper('addHyphensDate').func('20011201'));
+        assert.strictEqual('2001-12-31', getHelper('addHyphensDate').func('20011231'));
+        assert.strictEqual('2001-01-31', getHelper('addHyphensDate').func('20010131'));
+        assert.strictEqual('2001-01-31', getHelper('addHyphensDate').func('2001013100'));
+        assert.strictEqual('2001-01-31', getHelper('addHyphensDate').func('200101310000'));
     });
 
     it('getFirstCdaSections should return a dictionary with first instance of sections', function (done) {

--- a/src/lib/handlebars-converter/handlebars-helpers.spec.js
+++ b/src/lib/handlebars-converter/handlebars-helpers.spec.js
@@ -103,6 +103,15 @@ describe('Handlebars helpers', function () {
         { f: 'toJsonString', in: [["a", "b"]], out: '["a","b"]' },
         { f: 'addHyphensSSN', in: [undefined], out: "" },
         { f: 'addHyphensDate', in: [undefined], out: "" },
+        { f: 'addHyphensDate', in: ["2001"], out: "2001" },
+        { f: 'addHyphensDate', in: ["200101"], out: "2001-01" },
+        { f: 'addHyphensDate', in: ["200106"], out: "2001-06" },
+        { f: 'addHyphensDate', in: ["200112"], out: "2001-12" },
+        { f: 'addHyphensDate', in: ["20011201"], out: "2001-12-01" },
+        { f: 'addHyphensDate', in: ["20011231"], out: "2001-12-31" },
+        { f: 'addHyphensDate', in: ["20010131"], out: "2001-01-31" },
+        { f: 'addHyphensDate', in: ["2001013100"], out: "2001-01-31" },
+        { f: 'addHyphensDate', in: ["200101310000"], out: "2001-01-31" },
         { f: 'formatAsDateTime', in: [undefined], out: "" },
         { f: 'formatAsDateTime', in: ["2004"], out: "2004"}, 
         { f: 'formatAsDateTime', in: ["200401"], out: "2004-01"}, 
@@ -278,24 +287,6 @@ describe('Handlebars helpers', function () {
         assert.strictEqual('123', getHelper('addHyphensSSN').func('123'));
         assert.strictEqual('111111111111', getHelper('addHyphensSSN').func('111111111111'));
         assert.strictEqual('123-45-67', getHelper('addHyphensSSN').func('123-45-67'));
-    });
-
-    it('addHyphensDate adds hyphens when passed 4 digits', function() {
-        assert.strictEqual('2001', getHelper('addHyphensDate').func('2001'));
-    });
-
-    it('addHyphensDate adds hyphens when passed 6 digits', function() {
-        assert.strictEqual('2001-01', getHelper('addHyphensDate').func('200101'));
-        assert.strictEqual('2001-06', getHelper('addHyphensDate').func('200106'));
-        assert.strictEqual('2001-12', getHelper('addHyphensDate').func('200112'));
-    });
-
-    it('addHyphensDate adds hyphens when passed more than 8 digits', function() {
-        assert.strictEqual('2001-12-01', getHelper('addHyphensDate').func('20011201'));
-        assert.strictEqual('2001-12-31', getHelper('addHyphensDate').func('20011231'));
-        assert.strictEqual('2001-01-31', getHelper('addHyphensDate').func('20010131'));
-        assert.strictEqual('2001-01-31', getHelper('addHyphensDate').func('2001013100'));
-        assert.strictEqual('2001-01-31', getHelper('addHyphensDate').func('200101310000'));
     });
 
     it('getFirstCdaSections should return a dictionary with first instance of sections', function (done) {


### PR DESCRIPTION
## Description

Fix the date format conversion 

## Related issues
Addresses #74191

## Testing

The reason for the incorrect date conversion is that the original code didn’t check the different input formats of date from CDA and just simply output all the date as UTC format by filling the zero. For example:

1.Just year + month (+day): 
- Input: `<effectiveTime value="199911"/>`
- Output: `"occurrenceDateTime": "1999-10-31T00:00:00.000Z "`

2.Bad input format 
- Input: `<effectiveTime value="19991"/>`
- Output: `"occurrenceDateTime": "1999-09-30T00:00:00.000Z "`

I added some validation for the inputs which will throw exceptions for bad inputs, fixed the bug according to the specs of FHIR (https://www.hl7.org/fhir/datatypes.html#dateTime). For example: 
1.Just year + month (+day):  
- Input: `<effectiveTime value="199911"/>`
- Output: `"occurrenceDateTime": "1999-11"`

2.Bad input format  (Now the converter will throw exceptions and inform the user)

3.UTC format
- Input: `<effectiveTime value="19991101020203200"/>`
- Output: `"occurrenceDateTime": "1999-11-01T02:02:03.200Z"`

