### PR TITLE
Personal/yankun/handleIdError

### DIFF
--- a/src/templates/cda/Resources/Composition.hbs
+++ b/src/templates/cda/Resources/Composition.hbs
@@ -76,7 +76,7 @@
                                     {{/each}}
                                 {{/each}}
                             {{else if resObj.resourceType}}
-                                {{#each ../this.section.entry}}                           	
+                                {{#each (toArray../this.section.entry)}}                           	
                                     {
                                         "reference":"{{concat resObj.resourceType '/' (generateUUID (toJsonString this))}}",
                                         {{>Utils/DisplayFromSectionEntry.hbs section=../../this.section entry=this}}

--- a/src/templates/cda/Resources/Composition.hbs
+++ b/src/templates/cda/Resources/Composition.hbs
@@ -76,7 +76,7 @@
                                     {{/each}}
                                 {{/each}}
                             {{else if resObj.resourceType}}
-                                {{#each (toArray../this.section.entry)}}                           	
+                                {{#each (toArray ../this.section.entry)}}                           	
                                     {
                                         "reference":"{{concat resObj.resourceType '/' (generateUUID (toJsonString this))}}",
                                         {{>Utils/DisplayFromSectionEntry.hbs section=../../this.section entry=this}}


### PR DESCRIPTION
## Description

Handling the ID error

## Testing

The problems are:
(1) Generate redundant and nonexistent references, which is shown in ‘output_before_fixing.json’:
Line 109: "reference": "Encounter/6636b54e-61e2-3aae-91c4-91d1e881b1af"
Line 112: "reference": "Encounter/3b283aef-64d0-3082-8c13-401b8e0c7a84"
Line 133: "reference": "FamilyMemberHistory/6636b54e-61e2-3aae-91c4-91d1e881b1af"
Line 266: "reference": "Coverage/6636b54e-61e2-3aae-91c4-91d1e881b1af"

(2) The reference ID is inconsistent with the actual resource ID. For example, for the resource Encounter, we just have one Encounter ‘aa44c032-eb27-31aa-9d37-936d2522ad81’ in ‘C-CDA_R2-1_CCD.xml’ while we have a wrong reference ‘3b283aef-64d0-3082-8c13-401b8e0c7a84’, which is shown in ‘output_before_fixing.json’:
Line 109: "reference": "Encounter/6636b54e-61e2-3aae-91c4-91d1e881b1af"
Line 112: "reference": "Encounter/3b283aef-64d0-3082-8c13-401b8e0c7a84"
Line 2435:
{
      "fullUrl": "urn:uuid:aa44c032-eb27-31aa-9d37-936d2522ad81",
      "resource": {
        "resourceType": "Encounter",
        "id": "aa44c032-eb27-31aa-9d37-936d2522ad81",
        "status": "unknown", …
}

After fixing, we can see that the reference is created correctly and redundant references will not be created, which is shown in ‘output_after_fixing.json’:
Line 109: " reference": "Encounter/aa44c032-eb27-31aa-9d37-936d2522ad81"
Line 2426:
{
      "fullUrl": "urn:uuid:aa44c032-eb27-31aa-9d37-936d2522ad81",
      "resource": {
        "resourceType": "Encounter",
        "id": "aa44c032-eb27-31aa-9d37-936d2522ad81",
        "status": "unknown", …
}
 
