### PR TITLE
fix the error returned when parsing fails

### DIFF
--- a/src/lib/hl7v2/hl7v2.js
+++ b/src/lib/hl7v2/hl7v2.js
@@ -6,8 +6,6 @@ var specialCharProcessor = require('../inputProcessor/specialCharProcessor');
 var hl7SequenceHandler = require('./hl7EscapeSequence');
 var hl7v2TemplatePreprocessor = require('../inputProcessor/templatePreprocessor');
 var CoverageArray = require('./coverage-array');
-var errorCodes = require('../error/error').errorCodes;
-var errorMessage = require('../error/error').errorMessage;
 var dataHandler = require('../dataHandler/dataHandler');
 
 module.exports = class hl7v2 extends dataHandler {
@@ -23,7 +21,7 @@ module.exports = class hl7v2 extends dataHandler {
                 fulfill(data);
             }
             catch (err) {
-                reject(errorMessage(errorCodes.BadRequest, err.message));
+                reject(err);
             }
         });
     }

--- a/src/lib/workers/worker.js
+++ b/src/lib/workers/worker.js
@@ -106,7 +106,7 @@ WorkerUtils.workerTaskProcessor((msg) => {
 
                                 })
                                 .catch(err => {
-                                    reject({ 'status': 400, 'resultMsg': errorMessage(errorCodes.BadRequest, `Unable to parse input data. ${err.error.message}`) });
+                                    reject({ 'status': 400, 'resultMsg': errorMessage(errorCodes.BadRequest, `Unable to parse input data. ${err.toString()}`) });
                                 });
                         }
                         catch (err) {
@@ -181,7 +181,7 @@ WorkerUtils.workerTaskProcessor((msg) => {
                                     });
                             })
                             .catch(err => {
-                                reject({ 'status': 400, 'resultMsg': errorMessage(errorCodes.BadRequest, `Unable to parse input data. ${err.error.message}`) });
+                                reject({ 'status': 400, 'resultMsg': errorMessage(errorCodes.BadRequest, `Unable to parse input data. ${err.toString()}`) });
                             });
                     }
                     break;

--- a/src/routes.spec.js
+++ b/src/routes.spec.js
@@ -888,7 +888,7 @@ describe('POST /api/convert/hl7v2 (inline conversion)', function () {
             .expect(400, {
                 error: {
                     code: "BadRequest",
-                    message: "Unable to parse input data. Invalid HL7 v2 message, first segment id = MSQ"
+                    message: "Unable to parse input data. Error: Invalid HL7 v2 message, first segment id = MSQ"
                 }
             })
             .end(function (err) {
@@ -1621,7 +1621,7 @@ describe('POST /api/convert/hl7v2/:template (with stored template)', function ()
             .expect(400, {
                 error: {
                     code: "BadRequest",
-                    message: "Unable to parse input data. Invalid HL7 v2 message, first segment id = MSQ"
+                    message: "Unable to parse input data. Error: Invalid HL7 v2 message, first segment id = MSQ"
                 }
             })
             .end(function (err) {


### PR DESCRIPTION
fix the error returned when parsing fails. Bug was caused due to incorrect assumption on the err object.

## Description

fix the error returned when parsing fails. Bug was caused due to incorrect assumption on the err object.

## Related issues

Addresses #74409

## Testing

unit tests and manual testing.
