### PR TITLE
revert eq/ne helpers due to the bug 74581

### DIFF
--- a/src/lib/handlebars-converter/handlebars-helpers.js
+++ b/src/lib/handlebars-converter/handlebars-helpers.js
@@ -178,14 +178,14 @@ module.exports.external = [
         name: 'eq',
         description: 'Equals at least one of the values: eq x a b …',
         func: function (x, ...values) {
-            return Array.prototype.slice.call(values.slice(0, -1)).some(a => x === a); //last element is full msg
+            return Array.prototype.slice.call(values.slice(0, -1)).some(a => x == a); //last element is full msg
         }
     },
     {
         name: 'ne',
         description: 'Not equal to any value: ne x a b …',
         func: function (x, ...values) {
-            return Array.prototype.slice.call(values.slice(0, -1)).every(a => x !== a); //last element is full msg
+            return Array.prototype.slice.call(values.slice(0, -1)).every(a => x != a); //last element is full msg
         }
     },
     {


### PR DESCRIPTION
## Description

Story:
V2 templates were released earlier than the CCDA templates. some customers may already be using it,  so we want to protect the V2 behavior. Changing the behavior will break their templates and they will have to re-write those.

The cause of bug:
In version 2.0, I found that the helpers 'eq' and 'ne' have been modified. They are changed from equality operator ('==') to strong equality operator  ('==='), inequality operator ('!=') to strong inequality operator ('!=='). Strong equality operator returns true only when the type and value are the same, so when the types are different, false will be returned. Therefore, for the case in bug 74581, when we only use '"status":{{>DataType/_string.hbs mapping="CodeSystem/ResultStatus.hbs" inCode=OBR-25 }}' in the template 'Resources/DiagnosticReport.hbs', the inCode we get is an object type actually, not equal to a string 'F'. 
The detailed discussion can be seen in the discussion area of bug #74581.

## Related issues

Addresses bug #74581.

## Testing

I took the CCDA samples in the repo and used the two variations of eq to generate the outputs, and verified that the outputs are same.  