### PR TITLE
Fix component overlap

### DIFF
--- a/src/lib/hl7v2/hl7v2.js
+++ b/src/lib/hl7v2/hl7v2.js
@@ -98,15 +98,14 @@ function parseHL7v2(msg) {
                     }
                     else {
                         var ocomps = CoverageArray.makeCoverageArray();
-
+                        var reps = fields[f].split(repetitionSeparator);
                         createComponents(ocomps,
-                            fields[f],
+                            reps[0],
                             fieldSeparator,
                             componentSeparator,
                             subcomponentSeparator,
                             repetitionSeparator);
-
-                        var reps = fields[f].split(repetitionSeparator);
+                        
                         for (var repId = 0; repId < reps.length; repId++) {
                             let repIdArr = [];
                             createComponents(repIdArr,

--- a/src/lib/hl7v2/hl7v2.spec.js
+++ b/src/lib/hl7v2/hl7v2.spec.js
@@ -58,6 +58,20 @@ describe('hl7v2', function () {
             .then(() => assert.fail())
             .catch(() => done());
     });
+
+    var overlapTests = [
+        { "message": "MSH|^~\\&|||||20190502121659.069-0700\nNK1|||||(130) 724-0433^PRN^PH^^^431^2780404~(330) 274-8214^ORN^PH^^^330^2748214", "result": 7 },
+        { "message": "MSH|^~\\&|||||20190502121659.069-0700\nNK1|||||~(330) 274-8214^ORN^PH^^^330^2748214", "result": 1 }
+    ];
+    overlapTests.forEach(overlapTest =>{
+        it('should return correct correct components without overlapping repetitions', function (done) {
+            new hl7().parseSrcData(overlapTest.message)
+                .then((out) => {
+                    done(assert.equal(out.v2.data[1][4].length, overlapTest.result) && assert.equal(out.v2.data[1][4].repeats.length, 2));
+                })
+                .catch(() => assert.fail());
+        });
+    });
 });
 
 describe('hl7.parseCoverageReport', function () {


### PR DESCRIPTION
Current engine parses the whole string of a field into components. This could be wrong when field contains repetitions.

For example, the input segment is:
<pre>NK1|||||(130) 724-0433^PRN^PH^^^431^2780404~(330) 274-8214^ORN^PH^^^330^2748214</pre>
The engine parses NK1.5 into a list of components:
<pre>(130) 724-0433, PRN, PH, null, null, 431, <b>2780404~(330) 274-8214</b>, ORN, PH, null, null, 330, 2748214</pre>
The 7th component and ones after are wrong.

The fix is to split the field into repetitions first, and parse the **first** repetition as components, and all repetitions into `repeats`. Working item #76357 is created to track it.