### PR TITLE
2020.10.12 solved issue #78

### DIFF
--- a/src/static/js/template-editor.js
+++ b/src/static/js/template-editor.js
@@ -109,8 +109,9 @@ function convertData() {
         var outputLines = [];
 
         if (dataEditor.getValue() && dataEditor.getValue() !== "") {
-            // eslint-disable-next-line no-control-regex
-            reqBody.srcDataBase64 = btoa(dataEditor.getValue().replace(/[^\x00-\x7F]/g, "")); //TODO
+            // The following way can convert utf8 string to base64 string.
+            //   Ref: https://stackoverflow.com/questions/18729405/how-to-convert-utf8-string-to-byte-array/18729931
+            reqBody.srcDataBase64 = btoa(unescape(encodeURIComponent(dataEditor.getValue())));
         }
         else {
             return;


### PR DESCRIPTION
## Description

This issue occurs because the editor will remove all the non-latin characters to fit with the `window.btoa` function.
There is an easy way to accept utf8 characters using nested functions, see [here](https://stackoverflow.com/questions/18729405/how-to-convert-utf8-string-to-byte-array/18729931).

## Related issues

Addresses [issue #78 ].

## Testing

All unittests are passed.
