### PR TITLE
2020.10.20 fixed the terminology server connection issue inside the java validator

### DIFF
--- a/test/e2e-test/rule-test/util/test-rule-functions.js
+++ b/test/e2e-test/rule-test/util/test-rule-functions.js
@@ -102,9 +102,10 @@ const originValueReveal = (reqJson, resJson) => {
 const officialValidator = (reqJson, resJson) => {
     const javaExistCommand = 'java -version';
     const validatorPath = path.join(__dirname, '../lib/validator_cli.jar');
+    const specPath = 'http://hl7.org/fhir/us/core';
     const resourceFolder = path.join(__dirname, '../test-samples/tmp');
     const resourcePath = path.join(resourceFolder, `${uuidv4().replace(/-/g, '')}.json`);
-    const command = `java -jar ${validatorPath} ${resourcePath} -version 4.0.1 -ig http://hl7.org/fhir/us/core`;
+    const command = `java -jar ${validatorPath} ${resourcePath} -version 4.0.1 -ig ${specPath} -tx n/a`;
 
     fsExtra.ensureDirSync(resourceFolder);
     fsExtra.writeFileSync(resourcePath, JSON.stringify(resJson, null, 4));
@@ -142,4 +143,3 @@ module.exports = {
     originValueReveal,
     officialValidator
 };
-


### PR DESCRIPTION
## Description

Patching for the previous pull request.
**The teriminology server of java validator** was down just before merging. So the CI can't pass in the master branch (but it goes well before merging, or to say before the terminology server crashing). I modified the validator logic to omit touching remote terminology server.

## Testing

All tests and CI passed.
