### PR TITLE
fix: attaches the commitChanges() callback to the correct menu item

### DIFF
--- a/src/static/js/git-menu.js
+++ b/src/static/js/git-menu.js
@@ -8,8 +8,8 @@ function loadGitMenu() {
         $.getJSON('/api/templates/git/branches?code=' + getApiKey(), function (branches) {
             $("#git-dropdown").html('');
             if (status.length > 0) {
-                $("#git-dropdown").append("<a class=\"dropdown-item commit-link\" href=\"#\">Commit changes</a>");
-                $("#git-dropdown").on('click', 'a.commit-link', function () {
+                $("#git-dropdown").append("<a class=\"dropdown-item commit-link\" href=\"#\">Commit changes</a>").on('click', 'a.commit-link', function () 
+                {
                     commitChanges();
                 });
             } else {


### PR DESCRIPTION
## Description

This change attach the `commitChanges()` callback to the correct menu item, instead of the whole "Git" menu

## Related issues

Addresses #86.

## Testing

Watch the developer console and see that /commit is not called repeatedly for every single click on the menu.
