### PR TITLE
fix: added `type` to param file and `schema` to body

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -524,11 +524,13 @@ module.exports = function (app) {
      *         description: The file name
      *         required: true
      *         in: path
+     *         type: string
      *       - name: template
      *         description: The conversion template
      *         in: body
      *         required: true
-     *         type: string
+     *         schema:
+     *           type: string
      *       - name: code
      *         in: query
      *         description: 'API key'


### PR DESCRIPTION
## Description

The @swagger header for the `/api/templates/{file}` path was incorrect.  The parameter `name` and the body had some missing information.

## Related issues

Addresses #88.

## Testing
It was impossible to validate the swagger file generated when getting `api-docs.json`.  After this change, I could validate and and use it for server stub generation.
