### PR TITLE
Rename entryTemplate to rootTemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Here are the parameters that the tool accepts:
 | Option | Name | Optionality | Default | Description |
 | ----- | ----- | ----- |----- |----- |
 | -d | TemplateDirectory | Required | | Root directory of templates. |
-| -e | EntryTemplate | Required | | Name of root template. |
+| -r | RootTemplate | Required | | Name of root template. |
 | -c | InputDataContent | Optional| | Input data content. Specify OutputDataFile to get the results. |
 | -f | OutputDataFile | Optional | | Output data file. |
 | -i | InputDataFolder | Optional | | Input data folder. Specify OutputDataFolder to get the results.. |

--- a/docs/SnippetConcept.md
+++ b/docs/SnippetConcept.md
@@ -65,7 +65,7 @@ The reference ensures that when the condition resource is created, there is a re
 },
 ```
 
-When this template is called in the entry template, you must specify the values for **ID** and **REF**.
+When this template is called in the root template, you must specify the values for **ID** and **REF**.
 Below is the example in the ADT_A01 template, where a reference template is included.
 
 ```

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/FunctionalTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/FunctionalTests.cs
@@ -91,14 +91,14 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests
             Assert.True(exception.InnerException is DotLiquid.Exceptions.StackLevelException);
         }
 
-        private void TestByTemplate(string inputFile, string expectedFile, string entryTemplate)
+        private void TestByTemplate(string inputFile, string expectedFile, string rootTemplate)
         {
             var hl7v2Processor = new Hl7v2Processor();
             var templateDirectory = Path.Join(AppDomain.CurrentDomain.BaseDirectory, @"..\..\..\..\..\data\Templates\Hl7v2");
 
             var inputContent = File.ReadAllText(inputFile);
             var expectedContent = File.ReadAllText(expectedFile);
-            var actualContent = hl7v2Processor.Convert(inputContent, entryTemplate, new Hl7v2TemplateProvider(templateDirectory));
+            var actualContent = hl7v2Processor.Convert(inputContent, rootTemplate, new Hl7v2TemplateProvider(templateDirectory));
 
             // Remove ID
             var regex = new Regex(@"(?<=(""urn:uuid:|""|/))([A-Za-z0-9\-]{36})(?="")");

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/FunctionalTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/FunctionalTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using DotLiquid;
 using Microsoft.Health.Fhir.Liquid.Converter.Exceptions;
@@ -18,61 +19,57 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests
 {
     public class FunctionalTests
     {
-        public static IEnumerable<object[]> GetDataForADTA01()
-        {
-            yield return new object[] { @"..\..\..\..\..\data\SampleData\Hl7v2\ADT01-23.hl7", @"TestData\Expected\Hl7v2\ADT_A01\ADT01-23-expected.json" };
-            yield return new object[] { @"..\..\..\..\..\data\SampleData\Hl7v2\ADT01-28.hl7", @"TestData\Expected\Hl7v2\ADT_A01\ADT01-28-expected.json" };
-            yield return new object[] { @"..\..\..\..\..\data\SampleData\Hl7v2\ADT04-23.hl7", @"TestData\Expected\Hl7v2\ADT_A01\ADT04-23-expected.json" };
-            yield return new object[] { @"..\..\..\..\..\data\SampleData\Hl7v2\ADT04-251.hl7", @"TestData\Expected\Hl7v2\ADT_A01\ADT04-251-expected.json" };
-            yield return new object[] { @"..\..\..\..\..\data\SampleData\Hl7v2\ADT04-28.hl7", @"TestData\Expected\Hl7v2\ADT_A01\ADT04-28-expected.json" };
-        }
+        private static readonly string DataFolder = @"..\..\..\..\..\data\SampleData";
+        private static readonly string ExpectedDataFolder = @"TestData\Expected";
+        private static readonly string Hl7v2TemplateFolder = @"..\..\..\..\..\data\Templates\Hl7v2";
 
-        public static IEnumerable<object[]> GetDataForVXUV04()
+        public static IEnumerable<object[]> GetDataForHl7v2()
         {
-            yield return new object[] { @"..\..\..\..\..\data\SampleData\Hl7v2\IZ_1_1.1_Admin_Child_Max_Message.hl7", @"TestData\Expected\Hl7v2\VXU_V04\IZ_1_1.1_Admin_Child_Max_Message-expected.json" };
-            yield return new object[] { @"..\..\..\..\..\data\SampleData\Hl7v2\VXU.hl7", @"TestData\Expected\Hl7v2\VXU_V04\VXU-expected.json" };
-        }
-
-        public static IEnumerable<object[]> GetDataForORUR01()
-        {
-            yield return new object[] { @"..\..\..\..\..\data\SampleData\Hl7v2\LAB-ORU-1.hl7", @"TestData\Expected\Hl7v2\ORU_R01\LAB-ORU-1-expected.json" };
-            yield return new object[] { @"..\..\..\..\..\data\SampleData\Hl7v2\LAB-ORU-2.hl7", @"TestData\Expected\Hl7v2\ORU_R01\LAB-ORU-2-expected.json" };
-            yield return new object[] { @"..\..\..\..\..\data\SampleData\Hl7v2\LRI_2.0-NG_CBC_Typ_Message.hl7", @"TestData\Expected\Hl7v2\ORU_R01\LRI_2.0-NG_CBC_Typ_Message-expected.json" };
-            yield return new object[] { @"..\..\..\..\..\data\SampleData\Hl7v2\ORU-R01-RMGEAD.hl7", @"TestData\Expected\Hl7v2\ORU_R01\ORU-R01-RMGEAD-expected.json" };
-        }
-
-        public static IEnumerable<object[]> GetDataForOMLO21()
-        {
-            yield return new object[] { @"..\..\..\..\..\data\SampleData\Hl7v2\MDHHS-OML-O21-1.hl7", @"TestData\Expected\Hl7v2\OML_O21\MDHHS-OML-O21-1-expected.json" };
-            yield return new object[] { @"..\..\..\..\..\data\SampleData\Hl7v2\MDHHS-OML-O21-2.hl7", @"TestData\Expected\Hl7v2\OML_O21\MDHHS-OML-O21-2-expected.json" };
-        }
-
-        [Theory]
-        [MemberData(nameof(GetDataForADTA01))]
-        public void GivenADTA01Message_WhenConverting_ExpectedFhirResourceShouldBeReturned(string inputFile, string expectedFile)
-        {
-            TestByTemplate(inputFile, expectedFile, "ADT_A01");
+            var data = new List<object[]>
+            {
+                new object[] { @"ADT_A01", @"ADT01-23.hl7", @"ADT01-23-expected.json" },
+                new object[] { @"ADT_A01", @"ADT01-28.hl7", @"ADT01-28-expected.json" },
+                new object[] { @"ADT_A01", @"ADT04-23.hl7", @"ADT04-23-expected.json" },
+                new object[] { @"ADT_A01", @"ADT04-251.hl7", @"ADT04-251-expected.json" },
+                new object[] { @"ADT_A01", @"ADT04-28.hl7", @"ADT04-28-expected.json" },
+                new object[] { @"OML_O21", @"MDHHS-OML-O21-1.hl7", @"MDHHS-OML-O21-1-expected.json" },
+                new object[] { @"OML_O21", @"MDHHS-OML-O21-2.hl7", @"MDHHS-OML-O21-2-expected.json" },
+                new object[] { @"ORU_R01", @"LAB-ORU-1.hl7", @"LAB-ORU-1-expected.json" },
+                new object[] { @"ORU_R01", @"LAB-ORU-2.hl7", @"LAB-ORU-2-expected.json" },
+                new object[] { @"ORU_R01", @"LRI_2.0-NG_CBC_Typ_Message.hl7", @"LRI_2.0-NG_CBC_Typ_Message-expected.json" },
+                new object[] { @"ORU_R01", @"ORU-R01-RMGEAD.hl7", @"ORU-R01-RMGEAD-expected.json" },
+                new object[] { @"VXU_V04", @"IZ_1_1.1_Admin_Child_Max_Message.hl7", @"IZ_1_1.1_Admin_Child_Max_Message-expected.json" },
+                new object[] { @"VXU_V04", @"VXU.hl7", @"VXU-expected.json" },
+            };
+            return data.Select(item => new object[]
+            {
+                Convert.ToString(item[0]),
+                Path.Combine(DataFolder, "Hl7v2", Convert.ToString(item[1])),
+                Path.Combine(ExpectedDataFolder, "Hl7v2", Convert.ToString(item[0]), Convert.ToString(item[2])),
+            });
         }
 
         [Theory]
-        [MemberData(nameof(GetDataForVXUV04))]
-        public void GivenVXUV04Message_WhenConverting_ExpectedFhirResourceShouldBeReturned(string inputFile, string expectedFile)
+        [MemberData(nameof(GetDataForHl7v2))]
+        public void GivenHl7v2Message_WhenConverting_ExpectedFhirResourceShouldBeReturned(string rootTemplate, string inputFile, string expectedFile)
         {
-            TestByTemplate(inputFile, expectedFile, "VXU_V04");
-        }
+            var hl7v2Processor = new Hl7v2Processor();
+            var templateDirectory = Path.Join(AppDomain.CurrentDomain.BaseDirectory, Hl7v2TemplateFolder);
 
-        [Theory]
-        [MemberData(nameof(GetDataForORUR01))]
-        public void GivenORUR01Message_WhenConverting_ExpectedFhirResourceShouldBeReturned(string inputFile, string expectedFile)
-        {
-            TestByTemplate(inputFile, expectedFile, "ORU_R01");
-        }
+            var inputContent = File.ReadAllText(inputFile);
+            var expectedContent = File.ReadAllText(expectedFile);
+            var actualContent = hl7v2Processor.Convert(inputContent, rootTemplate, new Hl7v2TemplateProvider(templateDirectory));
 
-        [Theory]
-        [MemberData(nameof(GetDataForOMLO21))]
-        public void GivenOMLO21Message_WhenConverting_ExpectedFhirResourceShouldBeReturned(string inputFile, string expectedFile)
-        {
-            TestByTemplate(inputFile, expectedFile, "OML_O21");
+            // Remove ID
+            var regex = new Regex(@"(?<=(""urn:uuid:|""|/))([A-Za-z0-9\-]{36})(?="")");
+            expectedContent = regex.Replace(expectedContent, string.Empty);
+            actualContent = regex.Replace(actualContent, string.Empty);
+
+            // Normalize time zone
+            JsonSerializer serializer = new JsonSerializer { DateTimeZoneHandling = DateTimeZoneHandling.Utc };
+            var expectedObject = serializer.Deserialize<JObject>(new JsonTextReader(new StringReader(expectedContent)));
+            var actualObject = serializer.Deserialize<JObject>(new JsonTextReader(new StringReader(actualContent)));
+            Assert.True(JToken.DeepEquals(expectedObject, actualObject));
         }
 
         [Fact]
@@ -89,27 +86,6 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests
 
             var exception = Assert.Throws<RenderException>(() => hl7v2Processor.Convert(@"MSH|^~\&|", "template", new Hl7v2TemplateProvider(templateSet)));
             Assert.True(exception.InnerException is DotLiquid.Exceptions.StackLevelException);
-        }
-
-        private void TestByTemplate(string inputFile, string expectedFile, string rootTemplate)
-        {
-            var hl7v2Processor = new Hl7v2Processor();
-            var templateDirectory = Path.Join(AppDomain.CurrentDomain.BaseDirectory, @"..\..\..\..\..\data\Templates\Hl7v2");
-
-            var inputContent = File.ReadAllText(inputFile);
-            var expectedContent = File.ReadAllText(expectedFile);
-            var actualContent = hl7v2Processor.Convert(inputContent, rootTemplate, new Hl7v2TemplateProvider(templateDirectory));
-
-            // Remove ID
-            var regex = new Regex(@"(?<=(""urn:uuid:|""|/))([A-Za-z0-9\-]{36})(?="")");
-            expectedContent = regex.Replace(expectedContent, string.Empty);
-            actualContent = regex.Replace(actualContent, string.Empty);
-
-            // Normalize time zone
-            JsonSerializer serializer = new JsonSerializer { DateTimeZoneHandling = DateTimeZoneHandling.Utc };
-            var expectedObject = serializer.Deserialize<JObject>(new JsonTextReader(new StringReader(expectedContent)));
-            var actualObject = serializer.Deserialize<JObject>(new JsonTextReader(new StringReader(actualContent)));
-            Assert.True(JToken.DeepEquals(expectedObject, actualObject));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/ConverterLogicHandler.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/ConverterLogicHandler.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Tool
                 var dataType = GetDataTypes(options.TemplateDirectory);
                 var dataProcessor = CreateDataProcessor(dataType);
                 var templateProvider = CreateTemplateProvider(dataType, options.TemplateDirectory);
-                var resultString = dataProcessor.Convert(options.InputDataContent, options.EntryTemplate, templateProvider);
+                var resultString = dataProcessor.Convert(options.InputDataContent, options.RootTemplate, templateProvider);
                 var result = new ConverterResult(ProcessStatus.OK, resultString);
                 WriteOutputFile(options.OutputDataFile, JsonConvert.SerializeObject(result, Formatting.Indented));
                 Logger.LogInformation("Process completed");
@@ -83,7 +83,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Tool
                 {
                     try
                     {
-                        var result = dataProcessor.Convert(File.ReadAllText(file), options.EntryTemplate, templateProvider);
+                        var result = dataProcessor.Convert(File.ReadAllText(file), options.RootTemplate, templateProvider);
                         var outputFileDirectory = Path.Join(options.OutputDataFolder, Path.GetRelativePath(options.InputDataFolder, Path.GetDirectoryName(file)));
                         var outputFilePath = Path.Join(outputFileDirectory, Path.GetFileNameWithoutExtension(file) + ".json");
                         WriteOutputFile(outputFilePath, result);

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Models/ConverterOptions.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Models/ConverterOptions.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Tool.Models
         [Option('d', "TemplateDirectory", Required = true, HelpText = "Root directory of templates")]
         public string TemplateDirectory { get; set; }
 
-        [Option('e', "EntryTemplate", Required = true, HelpText = "Name of entry template")]
-        public string EntryTemplate { get; set; }
+        [Option('r', "RootTemplate", Required = true, HelpText = "Name of root template")]
+        public string RootTemplate { get; set; }
 
         [Option('c', "InputDataContent", Required = false, HelpText = "Input data content. Please specify OutputDataFile to get the results.")]
         public string InputDataContent { get; set; }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/SegmentFiltersTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/SegmentFiltersTests.cs
@@ -42,6 +42,7 @@ RXA|0|1|20131112||88^influenza, unspecified formulation^CVX|999|||01^Historical 
             Assert.Equal(@"ORC|RE|4422^NIST-AA-IZ-2|13696^NIST-AA-IZ-2|||||||7824^Jackson^Lily^Suzanne^^^^^NIST-PI-1^L^^^PRN||654^Thomas^Wilma^Elizabeth^^^^^NIST-PI-1^L^^^MD|||||NISTEHRFAC^NISTEHRFacility^HL70362|", segments["ORC"].Value);
             Assert.True(!segments.ContainsKey("PV1"));
 
+            // Hl7v2Data and segment id content could not be null
             Assert.Throws<NullReferenceException>(() => Filters.GetFirstSegments(null, "PID"));
             Assert.Throws<NullReferenceException>(() => Filters.GetFirstSegments(new Hl7v2Data(), null));
         }
@@ -60,6 +61,7 @@ RXA|0|1|20131112||88^influenza, unspecified formulation^CVX|999|||01^Historical 
             Assert.Equal(4, segments["OBX"].Count);
             Assert.True(!segments.ContainsKey("PV1"));
 
+            // Hl7v2Data and segment id content could not be null
             Assert.Throws<NullReferenceException>(() => Filters.GetSegmentLists(null, "PID"));
             Assert.Throws<NullReferenceException>(() => Filters.GetSegmentLists(new Hl7v2Data(), null));
         }
@@ -82,6 +84,7 @@ RXA|0|1|20131112||88^influenza, unspecified formulation^CVX|999|||01^Historical 
             var pidSegments = Filters.GetRelatedSegmentList(data, orcSegment, "FOO");
             Assert.True(!pidSegments.ContainsKey("FOO"));
 
+            // Hl7v2Data could not be null
             Assert.Throws<NullReferenceException>(() => Filters.GetRelatedSegmentList(null, null, null));
         }
 
@@ -96,6 +99,7 @@ RXA|0|1|20131112||88^influenza, unspecified formulation^CVX|999|||01^Historical 
 
             Assert.Empty(Filters.GetParentSegment(data, "OBX", 4, "FOO"));
 
+            // Hl7v2Data could not be null
             Assert.Throws<NullReferenceException>(() => Filters.GetParentSegment(null, "OBX", 3, "RXA"));
         }
 
@@ -110,6 +114,7 @@ RXA|0|1|20131112||88^influenza, unspecified formulation^CVX|999|||01^Historical 
             Assert.True(Filters.HasSegments(data, "PID|ORC|OBX"));
             Assert.False(Filters.HasSegments(data, "PID|ORC|OBX||"));
 
+            // Hl7v2Data and segment id content could not be null
             Assert.Throws<NullReferenceException>(() => Filters.HasSegments(null, "PID"));
             Assert.Throws<NullReferenceException>(() => Filters.HasSegments(new Hl7v2Data(), null));
         }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Hl7v2ProcessorTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Hl7v2ProcessorTests.cs
@@ -90,12 +90,12 @@ SPM|1|||119297000^BLD^SCT^^^^^^Blood|||||||||||||20110103143428-0800
 
             var templateProvider = new Hl7v2TemplateProvider(templateSet);
 
-            // Null, empty or nonexistent entry template
+            // Null, empty or nonexistent root template
             var exception = Assert.Throws<RenderException>(() => processor.Convert(TestData, null, templateProvider));
-            Assert.Equal(FhirConverterErrorCode.NullOrEmptyEntryTemplate, exception.FhirConverterErrorCode);
+            Assert.Equal(FhirConverterErrorCode.NullOrEmptyRootTemplate, exception.FhirConverterErrorCode);
 
             exception = Assert.Throws<RenderException>(() => processor.Convert(TestData, string.Empty, templateProvider));
-            Assert.Equal(FhirConverterErrorCode.NullOrEmptyEntryTemplate, exception.FhirConverterErrorCode);
+            Assert.Equal(FhirConverterErrorCode.NullOrEmptyRootTemplate, exception.FhirConverterErrorCode);
 
             exception = Assert.Throws<RenderException>(() => processor.Convert(TestData, "NonExistentTemplateName", templateProvider));
             Assert.Equal(FhirConverterErrorCode.TemplateNotFound, exception.FhirConverterErrorCode);

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/SafeListTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/SafeListTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using Microsoft.Health.Fhir.Liquid.Converter.Hl7v2;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Hl7v2Processor.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Hl7v2Processor.cs
@@ -25,11 +25,11 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2
             _settings = processorSettings;
         }
 
-        public string Convert(string data, string entryTemplate, ITemplateProvider templateProvider, TraceInfo traceInfo = null)
+        public string Convert(string data, string rootTemplate, ITemplateProvider templateProvider, TraceInfo traceInfo = null)
         {
-            if (string.IsNullOrEmpty(entryTemplate))
+            if (string.IsNullOrEmpty(rootTemplate))
             {
-                throw new RenderException(FhirConverterErrorCode.NullOrEmptyEntryTemplate, Resources.NullOrEmptyEntryTemplate);
+                throw new RenderException(FhirConverterErrorCode.NullOrEmptyRootTemplate, Resources.NullOrEmptyRootTemplate);
             }
 
             if (templateProvider == null)
@@ -37,10 +37,10 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2
                 throw new RenderException(FhirConverterErrorCode.NullTemplateProvider, Resources.NullTemplateProvider);
             }
 
-            var template = templateProvider.GetTemplate(entryTemplate);
+            var template = templateProvider.GetTemplate(rootTemplate);
             if (template == null)
             {
-                throw new RenderException(FhirConverterErrorCode.TemplateNotFound, string.Format(Resources.TemplateNotFound, entryTemplate));
+                throw new RenderException(FhirConverterErrorCode.TemplateNotFound, string.Format(Resources.TemplateNotFound, rootTemplate));
             }
 
             var context = CreateContext(templateProvider, data);

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/IFhirConverter.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/IFhirConverter.cs
@@ -9,6 +9,6 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
 {
     public interface IFhirConverter
     {
-        public string Convert(string data, string entryTemplate, ITemplateProvider templateProvider, TraceInfo traceInfo = null);
+        public string Convert(string data, string rootTemplate, ITemplateProvider templateProvider, TraceInfo traceInfo = null);
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Models/FhirConverterErrorCode.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Models/FhirConverterErrorCode.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Models
         // RenderException
         TemplateRenderingError = 1401,
         PropertyNotFound = 1402,
-        NullOrEmptyEntryTemplate = 1403,
+        NullOrEmptyRootTemplate = 1403,
         NullTemplateProvider = 1404,
         TemplateNotFound = 1405,
 

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Resources.Designer.cs
@@ -160,20 +160,20 @@ namespace Microsoft.Health.Fhir.Liquid.Converter {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Entry template should not be nul or empty..
-        /// </summary>
-        internal static string NullOrEmptyEntryTemplate {
-            get {
-                return ResourceManager.GetString("NullOrEmptyEntryTemplate", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The input data should not be null or empty..
         /// </summary>
         internal static string NullOrEmptyInput {
             get {
                 return ResourceManager.GetString("NullOrEmptyInput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Root template should not be null or empty..
+        /// </summary>
+        internal static string NullOrEmptyRootTemplate {
+            get {
+                return ResourceManager.GetString("NullOrEmptyRootTemplate", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Resources.resx
@@ -150,11 +150,11 @@
   <data name="MissingHl7v2Separators" xml:space="preserve">
     <value>MSH segment misses separators.</value>
   </data>
-  <data name="NullOrEmptyEntryTemplate" xml:space="preserve">
-    <value>Entry template should not be nul or empty.</value>
-  </data>
   <data name="NullOrEmptyInput" xml:space="preserve">
     <value>The input data should not be null or empty.</value>
+  </data>
+  <data name="NullOrEmptyRootTemplate" xml:space="preserve">
+    <value>Root template should not be null or empty.</value>
   </data>
   <data name="NullTemplateProvider" xml:space="preserve">
     <value>TemplateProvider should not be null.</value>

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/SafeList.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/SafeList.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using DotLiquid;
 
-namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2
+namespace Microsoft.Health.Fhir.Liquid.Converter
 {
     public class SafeList<T> : IIndexable, ILiquidizable
         where T : class


### PR DESCRIPTION
## Description

- Update command-line option from `-e` to `-r` and rename `entryTemplate` to `rootTemplate` according to discussion in PR #94.
- Refine several tests.

## Related issues

Addresses [issue #].

## Testing

Describe how this change was tested.
