### PR TITLE
[DotLiquid] Update build pipeline

### DIFF
--- a/release.yml
+++ b/release.yml
@@ -45,11 +45,22 @@ steps:
     arguments: '--configuration $(buildConfiguration) --output $(Build.BinariesDirectory)/tool'
     nobuild: true
     publishWebProjects: false
-    zipAfterPublish: True
+    zipAfterPublish: true
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet publish'
+  inputs:
+    command: 'publish'
+    projects: '$(publishProject)'
+    arguments: '--configuration $(buildConfiguration) --output $(Build.SourcesDirectory)/bin/tool --runtime win-x64'
+    nobuild: true
+    publishWebProjects: false
+    zipAfterPublish: false
 
 - task: ArchiveFiles@2
   inputs:
     rootFolderOrFile: '$(Build.SourcesDirectory)/data/Templates/Hl7v2'
+    includeRootFolder: false
     archiveType: 'tar'
     tarCompression: 'gz'
     archiveFile: '$(Build.SourcesDirectory)/bin/DefaultTemplates.tar.gz'

--- a/release.yml
+++ b/release.yml
@@ -46,6 +46,13 @@ steps:
     nobuild: true
     publishWebProjects: false
     zipAfterPublish: True
+
+- task: ArchiveFiles@2
+  inputs:
+    rootFolderOrFile: '$(Build.SourcesDirectory)/data/Templates/Hl7v2'
+    archiveType: 'tar'
+    tarCompression: 'gz'
+    archiveFile: '$(Build.SourcesDirectory)/bin/DefaultTemplates.tar.gz'
       
 - task: DotNetCoreCLI@2
   displayName: 'dotnet pack nugets'

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Microsoft.Health.Fhir.Liquid.Converter.Tool.csproj
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Microsoft.Health.Fhir.Liquid.Converter.Tool.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
+    <NuspecFile>Microsoft.Health.Fhir.Liquid.Converter.Tool.nuspec</NuspecFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Microsoft.Health.Fhir.Liquid.Converter.Tool.nuspec
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Microsoft.Health.Fhir.Liquid.Converter.Tool.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Health.Fhir.Liquid.Converter.Tool</id>
+    <version>$version$</version>
+    <authors>Microsoft.Health.Fhir.Liquid.Converter.Tool</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Package Description</description>
+    <contentFiles>
+      <files include="any/netcoreapp3.1/**/*.*" buildAction="Content" copyToOutput="true" />
+    </contentFiles>
+  </metadata>
+  <files>
+    <file src="..\..\bin\tool\**" target="contentFiles\any\netcoreapp3.1" />
+  </files>
+</package>

--- a/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.Liquid.Converter.nuspec
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.Liquid.Converter.nuspec
@@ -33,6 +33,6 @@
   <files>
     <file src="bin\Release\netcoreapp3.1\Microsoft.Health.Fhir.Liquid.Converter.dll" target="lib\netcoreapp3.1" />
     <file src="bin\Release\netcoreapp3.1\Microsoft.Health.Fhir.TemplateManagement.dll" target="lib\netcoreapp3.1" />
-    <file src="..\..\data\DefaultTemplates.tar.gz" target="contentFiles\any\netcoreapp3.1" />
+    <file src="..\..\bin\DefaultTemplates.tar.gz" target="contentFiles\any\netcoreapp3.1" />
   </files>
 </package>


### PR DESCRIPTION
## Description

- Archive default templates in pipeline and pack it into NuGet package
- Pack self-contained windows binaries for VS code extension

Example packages could be found [here](https://microsofthealthoss.visualstudio.com/FhirServer/_build/results?buildId=7031&view=artifacts&pathAsName=false&type=publishedArtifacts).
Another PR will be created to remove the DefaultTemplates.tar.gz in current repo.

## Related issues

Addresses [issue #].

## Testing

Describe how this change was tested.
