### PR TITLE
[DotLiquid] Move evaluate tag registration in TemplateUtility

### DIFF
--- a/src/Microsoft.Health.Fhir.Liquid.Converter/DotLiquids/MemoryFileSystem.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/DotLiquids/MemoryFileSystem.cs
@@ -14,12 +14,6 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.DotLiquids
 {
     public class MemoryFileSystem : ITemplateFileSystem
     {
-        // Register "evaluate" tag in static constructor
-        static MemoryFileSystem()
-        {
-            Template.RegisterTag<Evaluate>("evaluate");
-        }
-
         protected List<Dictionary<string, Template>> TemplateCollection { get; set; } = new List<Dictionary<string, Template>>();
 
         public string ReadTemplateFile(Context context, string templateName)

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Utilities/TemplateUtility.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Utilities/TemplateUtility.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Text.RegularExpressions;
 using DotLiquid;
 using DotLiquid.Exceptions;
+using Microsoft.Health.Fhir.Liquid.Converter.DotLiquids;
 using Microsoft.Health.Fhir.Liquid.Converter.Exceptions;
 using Microsoft.Health.Fhir.Liquid.Converter.Hl7v2.Models;
 using Microsoft.Health.Fhir.Liquid.Converter.Models;
@@ -20,6 +21,12 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Utilities
     {
         private static readonly Regex FormatRegex = new Regex(@"(\\|/)_?");
         private const string TemplateFileExtension = ".liquid";
+
+        // Register "evaluate" tag in before Template.Parse
+        static TemplateUtility()
+        {
+            Template.RegisterTag<Evaluate>("evaluate");
+        }
 
         public static Dictionary<string, Template> ParseHl7v2Templates(Dictionary<string, string> templates)
         {


### PR DESCRIPTION
## Description

Move evaluate tag registration in `TemplateUtility`. We need to register this tag before `Template.ParseHl7v2Templates()` is called. In template management, it is called before creating `ITemplateProvider`.

## Related issues

Addresses [issue #].

## Testing

Describe how this change was tested.
