### PR TITLE
[DotLiquid] Refine template loading performance

### DIFF
--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/DotLiquids/EvaluateTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/DotLiquids/EvaluateTests.cs
@@ -7,13 +7,17 @@ using System.Collections.Generic;
 using System.Globalization;
 using DotLiquid;
 using DotLiquid.Exceptions;
+using Microsoft.Health.Fhir.Liquid.Converter.Exceptions;
 using Microsoft.Health.Fhir.Liquid.Converter.Hl7v2;
+using Microsoft.Health.Fhir.Liquid.Converter.Utilities;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.DotLiquids
 {
     public class EvaluateTests
     {
+        public const string TemplateName = "TemplateName";
+
         public static IEnumerable<object[]> GetValidEvaluateTemplateContents()
         {
             yield return new object[] { @"{% evaluate bundleId using 'ID/Bundle' -%}" };
@@ -41,11 +45,11 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.DotLiquids
         public void GivenValidEvaluateTemplateContent_WhenParseAndRender_CorrectResultShouldBeReturned(string templateContent)
         {
             // Template should be parsed correctly
-            var templateProvider = new Hl7v2TemplateProvider(Constants.Hl7v2TemplateDirectory);
-            var template = Template.Parse(templateContent);
+            var template = TemplateUtility.ParseTemplate(TemplateName, templateContent);
             Assert.True(template.Root.NodeList.Count > 0);
 
             // Template should be rendered correctly
+            var templateProvider = new Hl7v2TemplateProvider(Constants.Hl7v2TemplateDirectory);
             var context = new Context(
                 environments: new List<Hash>(),
                 outerScope: new Hash(),
@@ -62,17 +66,14 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.DotLiquids
         [MemberData(nameof(GetInvalidEvaluateTemplateContents))]
         public void GivenInvalidEvaluateTemplateContent_WhenParse_ExceptionsShouldBeThrown(string templateContent)
         {
-            var templateProvider = new Hl7v2TemplateProvider(Constants.Hl7v2TemplateDirectory);
-            Assert.Throws<SyntaxException>(() => Template.Parse(templateContent));
+            Assert.Throws<ConverterInitializeException>(() => TemplateUtility.ParseTemplate(TemplateName, templateContent));
         }
 
         [Fact]
         public void GivenInvalidSnippet_WhenRender_ExceptionsShouldBeThrown()
         {
-            var templateProvider = new Hl7v2TemplateProvider(Constants.Hl7v2TemplateDirectory);
-
             // No template file system
-            var template = Template.Parse(@"{% evaluate bundleId using 'ID/Bundle' Data: hl7v2Data -%}");
+            var template = TemplateUtility.ParseTemplate(TemplateName, @"{% evaluate bundleId using 'ID/Bundle' Data: hl7v2Data -%}");
             var context = new Context(
                 environments: new List<Hash>(),
                 outerScope: new Hash(),
@@ -84,7 +85,8 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.DotLiquids
             Assert.Throws<FileSystemException>(() => template.Render(RenderParameters.FromContext(context, CultureInfo.InvariantCulture)));
 
             // Valid template file system but no such template
-            template = Template.Parse(@"{% evaluate bundleId using 'ID/Foo' Data: hl7v2Data -%}");
+            template = TemplateUtility.ParseTemplate(TemplateName, @"{% evaluate bundleId using 'ID/Foo' Data: hl7v2Data -%}");
+            var templateProvider = new Hl7v2TemplateProvider(Constants.Hl7v2TemplateDirectory);
             context = new Context(
                 environments: new List<Hash>(),
                 outerScope: new Hash(),
@@ -93,7 +95,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.DotLiquids
                 maxIterations: 0,
                 timeout: 0,
                 formatProvider: CultureInfo.InvariantCulture);
-            Assert.Throws<Exceptions.RenderException>(() => template.Render(RenderParameters.FromContext(context, CultureInfo.InvariantCulture)));
+            Assert.Throws<ConverterInitializeException>(() => template.Render(RenderParameters.FromContext(context, CultureInfo.InvariantCulture)));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/DotLiquids/EvaluateTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/DotLiquids/EvaluateTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.DotLiquids
             var context = new Context(
                 environments: new List<Hash>(),
                 outerScope: new Hash(),
-                registers: Hash.FromAnonymousObject(new { file_system = templateProvider }),
+                registers: Hash.FromAnonymousObject(new { file_system = templateProvider.GetTemplateFileSystem() }),
                 errorsOutputMode: ErrorsOutputMode.Rethrow,
                 maxIterations: 0,
                 timeout: 0,
@@ -90,12 +90,12 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.DotLiquids
             context = new Context(
                 environments: new List<Hash>(),
                 outerScope: new Hash(),
-                registers: Hash.FromAnonymousObject(new { file_system = templateProvider }),
+                registers: Hash.FromAnonymousObject(new { file_system = templateProvider.GetTemplateFileSystem() }),
                 errorsOutputMode: ErrorsOutputMode.Rethrow,
                 maxIterations: 0,
                 timeout: 0,
                 formatProvider: CultureInfo.InvariantCulture);
-            Assert.Throws<ConverterInitializeException>(() => template.Render(RenderParameters.FromContext(context, CultureInfo.InvariantCulture)));
+            Assert.Throws<Exceptions.RenderException>(() => template.Render(RenderParameters.FromContext(context, CultureInfo.InvariantCulture)));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/DotLiquids/MemoryFileSystemTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/DotLiquids/MemoryFileSystemTests.cs
@@ -135,5 +135,13 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.DotLiquids
             context["hello"] = "hello";
             Assert.Throws<NotImplementedException>(() => templateProvider.ReadTemplateFile(context, "hello"));
         }
+
+        [Fact]
+        public void GivenAValidTemplateDirectory_WhenGetTemplate_CorrectResultsShouldBeReturned()
+        {
+            var templateProvider = new Hl7v2TemplateProvider(Constants.Hl7v2TemplateDirectory);
+            Assert.NotNull(templateProvider.GetTemplate("ADT_A01"));
+            Assert.Throws<ConverterInitializeException>(() => templateProvider.GetTemplate("Foo"));
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/DotLiquids/TemplateLocalFileSystemTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/DotLiquids/TemplateLocalFileSystemTests.cs
@@ -1,0 +1,56 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+using DotLiquid;
+using Microsoft.Health.Fhir.Liquid.Converter.DotLiquids;
+using Microsoft.Health.Fhir.Liquid.Converter.Exceptions;
+using Microsoft.Health.Fhir.Liquid.Converter.Models;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.DotLiquids
+{
+    public class TemplateLocalFileSystemTests
+    {
+        [Fact]
+        public void GivenAValidTemplateDirectory_WhenGetTemplate_CorrectResultsShouldBeReturned()
+        {
+            var templateLocalFileSystem = new TemplateLocalFileSystem(Constants.Hl7v2TemplateDirectory, DataType.Hl7v2);
+            var context = new Context(CultureInfo.InvariantCulture);
+
+            // Template exists
+            Assert.NotNull(templateLocalFileSystem.GetTemplate("ADT_A01"));
+
+            // Template does not exist
+            Assert.Null(templateLocalFileSystem.GetTemplate("Foo"));
+        }
+
+        [Fact]
+        public void GivenAValidTemplateDirectory_WhenGetTemplateWithContext_CorrectResultsShouldBeReturned()
+        {
+            var templateLocalFileSystem = new TemplateLocalFileSystem(Constants.Hl7v2TemplateDirectory, DataType.Hl7v2);
+            var context = new Context(CultureInfo.InvariantCulture);
+
+            // Template exists
+            context["ADT_A01"] = "ADT_A01";
+            Assert.NotNull(templateLocalFileSystem.GetTemplate(context, "ADT_A01"));
+
+            // Template does not exist
+            context["Foo"] = "Foo";
+            Assert.Throws<RenderException>(() => templateLocalFileSystem.GetTemplate(context, "Foo"));
+            Assert.Throws<RenderException>(() => templateLocalFileSystem.GetTemplate(context, "Bar"));
+        }
+
+        [Fact]
+        public void GivenAValidTemplateDirectory_WhenReadTemplateWithContext_ExceptionShouldBeThrown()
+        {
+            var templateLocalFileSystem = new TemplateLocalFileSystem(Constants.Hl7v2TemplateDirectory, DataType.Hl7v2);
+            var context = new Context(CultureInfo.InvariantCulture);
+            context["ADT_A01"] = "ADT_A01";
+            Assert.Throws<NotImplementedException>(() => templateLocalFileSystem.ReadTemplateFile(context, "hello"));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Hl7v2TemplateProviderTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Hl7v2TemplateProviderTests.cs
@@ -3,10 +3,11 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using System.IO;
+using DotLiquid;
 using Microsoft.Health.Fhir.Liquid.Converter.Exceptions;
 using Microsoft.Health.Fhir.Liquid.Converter.Hl7v2;
-using Microsoft.Health.Fhir.Liquid.Converter.Models;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Hl7v2
@@ -18,12 +19,13 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Hl7v2
         {
             // Valid template directory
             var templateProvider = new Hl7v2TemplateProvider(Constants.Hl7v2TemplateDirectory);
-            var templates = templateProvider.LoadCodeSystemMapping();
-            Assert.NotNull(templates[0]["CodeSystem/CodeSystem"]);
 
             // Invalid template directory
             Assert.Throws<ConverterInitializeException>(() => new Hl7v2TemplateProvider(string.Empty));
             Assert.Throws<ConverterInitializeException>(() => new Hl7v2TemplateProvider(Path.Join("a", "b", "c")));
+
+            // Template collection
+            templateProvider = new Hl7v2TemplateProvider(new List<Dictionary<string, Template>>());
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Hl7v2TemplateProviderTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Hl7v2TemplateProviderTests.cs
@@ -16,17 +16,14 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Hl7v2
         [Fact]
         public void GivenATemplateDirectory_WhenLoadTemplates_CorrectResultsShouldBeReturned()
         {
+            // Valid template directory
             var templateProvider = new Hl7v2TemplateProvider(Constants.Hl7v2TemplateDirectory);
-            Assert.True(templateProvider.GetTemplate("ADT_A01").Root.NodeList.Count > 0);
+            var templates = templateProvider.LoadCodeSystemMapping();
+            Assert.NotNull(templates[0]["CodeSystem/CodeSystem"]);
 
-            Assert.Throws<ConverterInitializeException>(() => templateProvider.LoadTemplates(null));
-            Assert.Throws<ConverterInitializeException>(() => templateProvider.LoadTemplates(string.Empty));
-            Assert.Throws<ConverterInitializeException>(() => templateProvider.LoadTemplates(Path.Join("a", "b", "c")));
-
-            var exception = Assert.Throws<ConverterInitializeException>(() => templateProvider.LoadTemplates(@"TestTemplates"));
-            Assert.Equal(FhirConverterErrorCode.TemplateLoadingError, exception.FhirConverterErrorCode);
-            var innerException = exception.InnerException as FhirConverterException;
-            Assert.Equal(FhirConverterErrorCode.TemplateSyntaxError, innerException.FhirConverterErrorCode);
+            // Invalid template directory
+            Assert.Throws<ConverterInitializeException>(() => new Hl7v2TemplateProvider(string.Empty));
+            Assert.Throws<ConverterInitializeException>(() => new Hl7v2TemplateProvider(Path.Join("a", "b", "c")));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/DotLiquids/MemoryFileSystem.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/DotLiquids/MemoryFileSystem.cs
@@ -5,23 +5,24 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using DotLiquid;
-using DotLiquid.FileSystems;
 using Microsoft.Health.Fhir.Liquid.Converter.Exceptions;
 using Microsoft.Health.Fhir.Liquid.Converter.Models;
-using Microsoft.Health.Fhir.Liquid.Converter.Utilities;
 
 namespace Microsoft.Health.Fhir.Liquid.Converter.DotLiquids
 {
-    public class MemoryFileSystem : ITemplateFileSystem
+    public class MemoryFileSystem : IFhirConverterTemplateFileSystem
     {
-        protected const string TemplateFileExtension = ".liquid";
+        private readonly List<Dictionary<string, Template>> _templateCollection;
 
-        protected string TemplateDirectory { get; set; }
-
-        protected List<Dictionary<string, Template>> TemplateCollection { get; set; }
+        public MemoryFileSystem(List<Dictionary<string, Template>> templateCollection)
+        {
+            _templateCollection = new List<Dictionary<string, Template>>();
+            foreach (var templates in templateCollection)
+            {
+                _templateCollection.Add(new Dictionary<string, Template>(templates));
+            }
+        }
 
         public string ReadTemplateFile(Context context, string templateName)
         {
@@ -33,7 +34,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.DotLiquids
             var templatePath = (string)context[templateName];
             if (templatePath == null)
             {
-                throw new RenderException(FhirConverterErrorCode.TemplateNotFound, string.Format(Resources.TemplateNotFound, templatePath));
+                throw new RenderException(FhirConverterErrorCode.TemplateNotFound, string.Format(Resources.TemplateNotFound, templateName));
             }
 
             return GetTemplate(templatePath) ?? throw new RenderException(FhirConverterErrorCode.TemplateNotFound, string.Format(Resources.TemplateNotFound, templatePath));
@@ -46,8 +47,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.DotLiquids
                 return null;
             }
 
-            // Get template from TemplateCollection first
-            foreach (var templates in TemplateCollection)
+            foreach (var templates in _templateCollection)
             {
                 if (templates != null && templates.ContainsKey(templateName))
                 {
@@ -55,60 +55,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.DotLiquids
                 }
             }
 
-            // If template not found but loaded from local file system, search local file system
-            if (TemplateDirectory != null)
-            {
-                if (TemplateCollection == null)
-                {
-                    TemplateCollection = new List<Dictionary<string, Template>>();
-                }
-
-                if (TemplateCollection.FirstOrDefault() == null)
-                {
-                    TemplateCollection.Add(new Dictionary<string, Template>());
-                }
-
-                var templatePath = GetAbsoluteTemplatePath(templateName);
-                var templateContent = LoadTemplate(templatePath);
-                var template = TemplateUtility.ParseTemplate(templateName, templateContent);
-                TemplateCollection[0][templateName] = template;
-                return template;
-            }
-
             return null;
-        }
-
-        protected string LoadTemplate(string templatePath)
-        {
-            try
-            {
-                return File.ReadAllText(templatePath);
-            }
-            catch (Exception ex)
-            {
-                throw new ConverterInitializeException(FhirConverterErrorCode.TemplateLoadingError, string.Format(Resources.TemplateLoadingError, ex.Message), ex);
-            }
-        }
-
-        private string GetAbsoluteTemplatePath(string templateName)
-        {
-            var result = TemplateDirectory;
-            var pathSegments = templateName.Split(Path.AltDirectorySeparatorChar);
-
-            // Root templates
-            if (pathSegments.Length == 1)
-            {
-                return Path.Join(TemplateDirectory, $"{pathSegments[0]}{TemplateFileExtension}");
-            }
-
-            // Snippets
-            pathSegments[^1] = $"_{pathSegments[^1]}{TemplateFileExtension}";
-            foreach (var pathSegment in pathSegments)
-            {
-                result = Path.Join(result, pathSegment);
-            }
-
-            return result;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/DotLiquids/TemplateLocalFileSystem.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/DotLiquids/TemplateLocalFileSystem.cs
@@ -1,0 +1,124 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using DotLiquid;
+using Microsoft.Health.Fhir.Liquid.Converter.Exceptions;
+using Microsoft.Health.Fhir.Liquid.Converter.Models;
+using Microsoft.Health.Fhir.Liquid.Converter.Utilities;
+
+namespace Microsoft.Health.Fhir.Liquid.Converter.DotLiquids
+{
+    public class TemplateLocalFileSystem : IFhirConverterTemplateFileSystem
+    {
+        private readonly string _templateDirectory;
+
+        private Dictionary<string, Template> _templateCache;
+
+        public TemplateLocalFileSystem(string templateDirectory, DataType dataType)
+        {
+            if (!Directory.Exists(templateDirectory))
+            {
+                throw new ConverterInitializeException(FhirConverterErrorCode.TemplateFolderNotFound, string.Format(Resources.TemplateFolderNotFound, templateDirectory));
+            }
+
+            _templateDirectory = templateDirectory;
+            _templateCache = new Dictionary<string, Template>();
+
+            if (dataType == DataType.Hl7v2)
+            {
+                LoadCodeSystemMappingTemplate();
+            }
+        }
+
+        public string ReadTemplateFile(Context context, string templateName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Template GetTemplate(Context context, string templateName)
+        {
+            var templatePath = (string)context[templateName];
+            if (templatePath == null)
+            {
+                throw new RenderException(FhirConverterErrorCode.TemplateNotFound, string.Format(Resources.TemplateNotFound, templateName));
+            }
+
+            return GetTemplate(templatePath) ?? throw new RenderException(FhirConverterErrorCode.TemplateNotFound, string.Format(Resources.TemplateNotFound, templatePath));
+        }
+
+        public Template GetTemplate(string templateName)
+        {
+            if (string.IsNullOrEmpty(templateName))
+            {
+                return null;
+            }
+
+            // Get template from cache first
+            if (_templateCache.ContainsKey(templateName))
+            {
+                return _templateCache[templateName];
+            }
+
+            // If not cached, search local file system
+            var templatePath = GetAbsoluteTemplatePath(templateName);
+            if (File.Exists(templatePath))
+            {
+                var templateContent = LoadTemplate(templatePath);
+                var template = TemplateUtility.ParseTemplate(templateName, templateContent);
+                _templateCache[templateName] = template;
+                return template;
+            }
+
+            return null;
+        }
+
+        private void LoadCodeSystemMappingTemplate()
+        {
+            var codeSystemMappingPath = Path.Join(_templateDirectory, "CodeSystem", "CodeSystem.json");
+            if (File.Exists(codeSystemMappingPath))
+            {
+                var content = LoadTemplate(codeSystemMappingPath);
+                var template = TemplateUtility.ParseCodeSystemMapping(content);
+                _templateCache["CodeSystem/CodeSystem"] = template;
+            }
+        }
+
+        protected string LoadTemplate(string templatePath)
+        {
+            try
+            {
+                return File.ReadAllText(templatePath);
+            }
+            catch (Exception ex)
+            {
+                throw new ConverterInitializeException(FhirConverterErrorCode.TemplateLoadingError, string.Format(Resources.TemplateLoadingError, ex.Message), ex);
+            }
+        }
+
+        private string GetAbsoluteTemplatePath(string templateName)
+        {
+            var result = _templateDirectory;
+            var pathSegments = templateName.Split(Path.AltDirectorySeparatorChar);
+
+            // Root templates
+            if (pathSegments.Length == 1)
+            {
+                return Path.Join(_templateDirectory, $"{pathSegments[0]}.liquid");
+            }
+
+            // Snippets
+            pathSegments[^1] = $"_{pathSegments[^1]}.liquid";
+            foreach (var pathSegment in pathSegments)
+            {
+                result = Path.Join(result, pathSegment);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/DotLiquids/TemplateLocalFileSystem.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/DotLiquids/TemplateLocalFileSystem.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.DotLiquids
             }
         }
 
-        protected string LoadTemplate(string templatePath)
+        private string LoadTemplate(string templatePath)
         {
             try
             {

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Hl7v2Processor.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Hl7v2Processor.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2
             var context = new Context(
                 environments: new List<Hash>() { Hash.FromAnonymousObject(new { hl7v2Data }) },
                 outerScope: new Hash(),
-                registers: Hash.FromAnonymousObject(new { file_system = templateProvider }),
+                registers: Hash.FromAnonymousObject(new { file_system = templateProvider.GetTemplateFileSystem() }),
                 errorsOutputMode: ErrorsOutputMode.Rethrow,
                 maxIterations: 0,
                 timeout: timeout,

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Hl7v2TemplateProvider.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Hl7v2TemplateProvider.cs
@@ -29,7 +29,11 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2
         public Hl7v2TemplateProvider(List<Dictionary<string, Template>> templateCollection)
         {
             TemplateDirectory = null;
-            TemplateCollection = templateCollection;
+            TemplateCollection = new List<Dictionary<string, Template>>();
+            foreach (var templates in templateCollection)
+            {
+                TemplateCollection.Add(new Dictionary<string, Template>(templates));
+            }
         }
 
         public List<Dictionary<string, Template>> LoadCodeSystemMapping()

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/IFhirConverterTemplateFileSystem.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/IFhirConverterTemplateFileSystem.cs
@@ -8,10 +8,8 @@ using DotLiquid.FileSystems;
 
 namespace Microsoft.Health.Fhir.Liquid.Converter
 {
-    public interface ITemplateProvider
+    public interface IFhirConverterTemplateFileSystem : ITemplateFileSystem
     {
         public Template GetTemplate(string templateName);
-
-        public ITemplateFileSystem GetTemplateFileSystem();
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/ITemplateProvider.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/ITemplateProvider.cs
@@ -3,15 +3,12 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Collections.Generic;
 using DotLiquid;
 
 namespace Microsoft.Health.Fhir.Liquid.Converter
 {
     public interface ITemplateProvider
     {
-        public List<Dictionary<string, Template>> LoadTemplates(string templateDirectory);
-
         public Template GetTemplate(Context context, string templateName);
 
         public Template GetTemplate(string templateName);

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Utilities/TemplateUtility.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Utilities/TemplateUtility.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Utilities
             return parsedTemplates;
         }
 
-        private static Template ParseCodeSystemMapping(string content)
+        public static Template ParseCodeSystemMapping(string content)
         {
             if (content == null)
             {
@@ -73,7 +73,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Utilities
             }
         }
 
-        private static Template ParseTemplate(string templateName, string content)
+        public static Template ParseTemplate(string templateName, string content)
         {
             if (content == null)
             {


### PR DESCRIPTION
When templates are loaded from local file system, the engine could load them gradually when they are used, instead of loading them at once from beginning. This helps improve the performance in VS Code extension.