### PR TITLE
Fix the handlebars-style reference ID in resource templates

### DIFF
--- a/data/Templates/Hl7v2/ADT_A01.liquid
+++ b/data/Templates/Hl7v2/ADT_A01.liquid
@@ -34,17 +34,17 @@
         {% if encounterId -%}
             {% include 'Resource/Encounter' PV1: firstSegments.PV1, PV2: firstSegments.PV2, ID: encounterId -%}
 
-            {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.3 -%}
-            {% if locationId -%}
-                {% include 'Resource/Location' PL: firstSegments.PV1.3, ID: locationId -%}
-                {% include 'Resource/Encounter' PV1: firstSegments.PV1, Location_ID_PV1_3: locationId, ID: encounterId -%}
+            {% evaluate locationId3 using 'ID/Location' PL: firstSegments.PV1.3 -%}
+            {% if locationId3 -%}
+                {% include 'Resource/Location' PL: firstSegments.PV1.3, ID: locationId3 -%}
             {% endif -%}
 
-            {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.6 -%}
-            {% if locationId -%}
-                {% include 'Resource/Location' PL: firstSegments.PV1.6, ID: locationId -%}
-                {% include 'Resource/Encounter' PV1: firstSegments.PV1, Location_ID_PV1_6: locationId, ID: encounterId -%}
+            {% evaluate locationId6 using 'ID/Location' PL: firstSegments.PV1.6 -%}
+            {% if locationId6 -%}
+                {% include 'Resource/Location' PL: firstSegments.PV1.6, ID: locationId6 -%}
             {% endif -%}
+
+            {% include 'Resource/Encounter' PV1: firstSegments.PV1, Location_ID_PV1_3: locationId3, Location_ID_PV1_6: locationId6, ID: encounterId -%}
 
             {% if patientId -%}
                 {% include 'Reference/Encounter/Subject' ID: encounterId, REF: fullPatientId -%}

--- a/data/Templates/Hl7v2/ADT_A01.liquid
+++ b/data/Templates/Hl7v2/ADT_A01.liquid
@@ -51,20 +51,22 @@
             {% endif -%}
         {% endif -%}
 
-        {% evaluate procedureId using 'ID/Procedure' PR1: firstSegments.PR1, baseId: patientId -%}
-        {% if procedureId -%}
-            {% include 'Resource/Procedure' PR1: firstSegments.PR1, ID: procedureId -%}
+        {% assign pr1SegmentLists = hl7v2Data | get_segment_lists: 'PR1' -%}
+        {% for pr1Segment in pr1SegmentLists.PR1 -%}
+            {% evaluate procedureId using 'ID/Procedure' PR1: pr1Segment, baseId: patientId -%}
+            {% if procedureId -%}
+                {% include 'Resource/Procedure' PR1: pr1Segment, ID: procedureId -%}
 
-            {% evaluate locationId using 'ID/Location' PL: firstSegments.PR1.23 -%}
-            {% if locationId -%}
-                {% include 'Resource/Location' PL: firstSegments.PR1.23, ID: locationId -%}
-                {% include 'Resource/Procedure' PR1: firstSegments.PR1, Location_ID_PR1_23: locationId, ID: procedureId -%}
-            {% endif -%}
+                {% evaluate locationId using 'ID/Location' PL: pr1Segment.23 -%}
+                {% if locationId -%}
+                    {% include 'Resource/Location' PL: pr1Segment.23, ID: locationId -%}
+                {% endif -%}
 
-            {% if patientId -%}
-                {% include 'Reference/Procedure/Subject' ID: procedureId, REF: fullPatientId -%}
+                {% if patientId -%}
+                    {% include 'Reference/Procedure/Subject' ID: procedureId, REF: fullPatientId -%}
+                {% endif -%}
             {% endif -%}
-        {% endif -%}
+        {% endfor -%}
         
         {% assign nk1SegmentLists = hl7v2Data | get_segment_lists: 'NK1' -%}
         {% for nk1Segment in nk1SegmentLists.NK1 -%}

--- a/data/Templates/Hl7v2/ADT_A01.liquid
+++ b/data/Templates/Hl7v2/ADT_A01.liquid
@@ -37,13 +37,13 @@
             {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.3 -%}
             {% if locationId -%}
                 {% include 'Resource/Location' PL: firstSegments.PV1.3, ID: locationId -%}
-                {% include 'Resource/Encounter' Location-ID-PV1-3: locationId, ID: encounterId -%}
+                {% include 'Resource/Encounter' PV1: firstSegments.PV1, Location_ID_PV1_3: locationId, ID: encounterId -%}
             {% endif -%}
 
             {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.6 -%}
             {% if locationId -%}
                 {% include 'Resource/Location' PL: firstSegments.PV1.6, ID: locationId -%}
-                {% include 'Resource/Encounter' Location-ID-PV1-6: locationId, ID: encounterId -%}
+                {% include 'Resource/Encounter' PV1: firstSegments.PV1, Location_ID_PV1_6: locationId, ID: encounterId -%}
             {% endif -%}
 
             {% if patientId -%}
@@ -58,7 +58,7 @@
             {% evaluate locationId using 'ID/Location' PL: firstSegments.PR1.23 -%}
             {% if locationId -%}
                 {% include 'Resource/Location' PL: firstSegments.PR1.23, ID: locationId -%}
-                {% include 'Resource/Procedure' Location-ID-PR1-23: locationId, ID: procedureId -%}
+                {% include 'Resource/Procedure' PR1: firstSegments.PR1, Location_ID_PR1_23: locationId, ID: procedureId -%}
             {% endif -%}
 
             {% if patientId -%}

--- a/data/Templates/Hl7v2/ADT_A01.liquid
+++ b/data/Templates/Hl7v2/ADT_A01.liquid
@@ -2,7 +2,7 @@
     "resourceType": "Bundle",
     "type": "transaction",
     "entry": [
-        {% assign firstSegments = hl7v2Data | get_first_segments: 'PID|PD1|PV1|PV2|AVR|MSH' -%}
+        {% assign firstSegments = hl7v2Data | get_first_segments: 'PID|PD1|PV1|PV2|PR1|AVR|MSH' -%}
 
         {% evaluate messageHeaderId using 'ID/MessageHeader' MSH: firstSegments.MSH -%}
         {% if messageHeaderId -%}
@@ -15,7 +15,7 @@
             {% include 'Resource/Patient' PID: firstSegments.PID, PD1: firstSegments.PD1, ID: patientId -%}
         {% endif -%}
 
-        {% evaluate provenanceId using 'ID/Provenance' MSH: firstSegments.MSH, baseID: patientId -%}
+        {% evaluate provenanceId using 'ID/Provenance' MSH: firstSegments.MSH, baseId: patientId -%}
         {% if provenanceId -%}
             {% include 'Resource/Provenance' MSH: firstSegments.MSH, ORC: firstSegments.ORC, ID: provenanceId -%}
         {% endif -%}
@@ -37,11 +37,13 @@
             {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.3 -%}
             {% if locationId -%}
                 {% include 'Resource/Location' PL: firstSegments.PV1.3, ID: locationId -%}
+                {% include 'Resource/Encounter' Location-ID-PV1-3: locationId, ID: encounterId -%}
             {% endif -%}
 
             {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.6 -%}
             {% if locationId -%}
                 {% include 'Resource/Location' PL: firstSegments.PV1.6, ID: locationId -%}
+                {% include 'Resource/Encounter' Location-ID-PV1-6: locationId, ID: encounterId -%}
             {% endif -%}
 
             {% if patientId -%}
@@ -49,23 +51,21 @@
             {% endif -%}
         {% endif -%}
 
-        {% assign pr1SegmentLists = hl7v2Data | get_segment_lists: 'PR1' -%}
-        {% for pr1Segment in pr1SegmentLists.PR1 -%}
-            {% evaluate procedureId using 'ID/Procedure' PR1: pr1Segment, baseId: patientId -%}
-            {% if procedureId -%}
-                {% include 'Resource/Procedure' PR1: pr1Segment, ID: procedureId -%}
+        {% evaluate procedureId using 'ID/Procedure' PR1: firstSegments.PR1, baseId: patientId -%}
+        {% if procedureId -%}
+            {% include 'Resource/Procedure' PR1: firstSegments.PR1, ID: procedureId -%}
 
-                {% evaluate locationId using 'ID/Location' PL: pr1Segment.23 -%}
-                {% if locationId -%}
-                    {% include 'Resource/Location' PL: pr1Segment.23, ID: locationId -%}
-                {% endif -%}
-
-                {% if patientId -%}
-                    {% include 'Reference/Procedure/Subject' ID: procedureId, REF: fullPatientId -%}
-                {% endif -%}
+            {% evaluate locationId using 'ID/Location' PL: firstSegments.PR1.23 -%}
+            {% if locationId -%}
+                {% include 'Resource/Location' PL: firstSegments.PR1.23, ID: locationId -%}
+                {% include 'Resource/Procedure' Location-ID-PR1-23: locationId, ID: procedureId -%}
             {% endif -%}
-        {% endfor -%}
 
+            {% if patientId -%}
+                {% include 'Reference/Procedure/Subject' ID: procedureId, REF: fullPatientId -%}
+            {% endif -%}
+        {% endif -%}
+        
         {% assign nk1SegmentLists = hl7v2Data | get_segment_lists: 'NK1' -%}
         {% for nk1Segment in nk1SegmentLists.NK1 -%}
             {% include 'Resource/Patient' NK1: nk1Segment, ID: patientId -%}

--- a/data/Templates/Hl7v2/ADT_A01.liquid
+++ b/data/Templates/Hl7v2/ADT_A01.liquid
@@ -2,7 +2,7 @@
     "resourceType": "Bundle",
     "type": "transaction",
     "entry": [
-        {% assign firstSegments = hl7v2Data | get_first_segments: 'PID|PD1|PV1|PV2|PR1|AVR|MSH' -%}
+        {% assign firstSegments = hl7v2Data | get_first_segments: 'PID|PD1|PV1|PV2|AVR|MSH' -%}
 
         {% evaluate messageHeaderId using 'ID/MessageHeader' MSH: firstSegments.MSH -%}
         {% if messageHeaderId -%}

--- a/data/Templates/Hl7v2/OML_O21.liquid
+++ b/data/Templates/Hl7v2/OML_O21.liquid
@@ -15,7 +15,7 @@
             {% include 'Resource/Patient' PID: firstSegments.PID, PD1: firstSegments.PD1, ID: patientId -%}
         {% endif -%}
 
-        {% evaluate provenanceId using 'ID/Provenance' MSH: firstSegments.MSH, baseID: patientId -%}
+        {% evaluate provenanceId using 'ID/Provenance' MSH: firstSegments.MSH, baseId: patientId -%}
         {% if provenanceId -%}
             {% include 'Resource/Provenance' MSH: firstSegments.MSH, ORC: firstSegments.ORC, ID: provenanceId -%}
         {% endif -%}
@@ -38,11 +38,13 @@
             {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.3 -%}
             {% if locationId -%}
                 {% include 'Resource/Location' PL: firstSegments.PV1.3, ID: locationId -%}
+                {% include 'Resource/Encounter' Location-ID-PV1-3: locationId, ID: encounterId -%}
             {% endif -%}
 
             {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.6 -%}
             {% if locationId -%}
                 {% include 'Resource/Location' PL: firstSegments.PV1.6, ID: locationId -%}
+                {% include 'Resource/Encounter' Location-ID-PV1-6: locationId, ID: encounterId -%}
             {% endif -%}
 
             {% if patientId -%}

--- a/data/Templates/Hl7v2/OML_O21.liquid
+++ b/data/Templates/Hl7v2/OML_O21.liquid
@@ -38,13 +38,13 @@
             {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.3 -%}
             {% if locationId -%}
                 {% include 'Resource/Location' PL: firstSegments.PV1.3, ID: locationId -%}
-                {% include 'Resource/Encounter' Location-ID-PV1-3: locationId, ID: encounterId -%}
+                {% include 'Resource/Encounter' PV1: firstSegments.PV1, Location_ID_PV1_3: locationId, ID: encounterId -%}
             {% endif -%}
 
             {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.6 -%}
             {% if locationId -%}
                 {% include 'Resource/Location' PL: firstSegments.PV1.6, ID: locationId -%}
-                {% include 'Resource/Encounter' Location-ID-PV1-6: locationId, ID: encounterId -%}
+                {% include 'Resource/Encounter' PV1: firstSegments.PV1, Location_ID_PV1_6: locationId, ID: encounterId -%}
             {% endif -%}
 
             {% if patientId -%}

--- a/data/Templates/Hl7v2/OML_O21.liquid
+++ b/data/Templates/Hl7v2/OML_O21.liquid
@@ -35,17 +35,17 @@
             {% assign fullEncounterId = encounterId | prepend: 'Encounter/' -%}
             {% include 'Resource/Encounter' PV1: firstSegments.PV1, PV2: firstSegments.PV2, ID: encounterId -%}
 
-            {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.3 -%}
-            {% if locationId -%}
-                {% include 'Resource/Location' PL: firstSegments.PV1.3, ID: locationId -%}
-                {% include 'Resource/Encounter' PV1: firstSegments.PV1, Location_ID_PV1_3: locationId, ID: encounterId -%}
+            {% evaluate locationId3 using 'ID/Location' PL: firstSegments.PV1.3 -%}
+            {% if locationId3 -%}
+                {% include 'Resource/Location' PL: firstSegments.PV1.3, ID: locationId3 -%}
             {% endif -%}
 
-            {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.6 -%}
-            {% if locationId -%}
-                {% include 'Resource/Location' PL: firstSegments.PV1.6, ID: locationId -%}
-                {% include 'Resource/Encounter' PV1: firstSegments.PV1, Location_ID_PV1_6: locationId, ID: encounterId -%}
+            {% evaluate locationId6 using 'ID/Location' PL: firstSegments.PV1.6 -%}
+            {% if locationId6 -%}
+                {% include 'Resource/Location' PL: firstSegments.PV1.6, ID: locationId6 -%}
             {% endif -%}
+
+            {% include 'Resource/Encounter' PV1: firstSegments.PV1, Location_ID_PV1_3: locationId3, Location_ID_PV1_6: locationId6, ID: encounterId -%}
 
             {% if patientId -%}
                 {% include 'Reference/Encounter/Subject' ID: encounterId, REF: fullPatientId -%}

--- a/data/Templates/Hl7v2/ORU_R01.liquid
+++ b/data/Templates/Hl7v2/ORU_R01.liquid
@@ -38,13 +38,13 @@
             {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.3 -%}
             {% if locationId -%}
                 {% include 'Resource/Location' PL: firstSegments.PV1.3, ID: locationId -%}
-                {% include 'Resource/Encounter' Location-ID-PV1-3: locationId, ID: encounterId -%}
+                {% include 'Resource/Encounter' PV1: firstSegments.PV1, Location_ID_PV1_3: locationId, ID: encounterId -%}
             {% endif -%}
 
             {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.6 -%}
             {% if locationId -%}
                 {% include 'Resource/Location' PL: firstSegments.PV1.6, ID: locationId -%}
-                {% include 'Resource/Encounter' Location-ID-PV1-6: locationId, ID: encounterId -%}
+                {% include 'Resource/Encounter' PV1: firstSegments.PV1, Location_ID_PV1_6: locationId, ID: encounterId -%}
             {% endif -%}
             
             {% if patientId -%}

--- a/data/Templates/Hl7v2/ORU_R01.liquid
+++ b/data/Templates/Hl7v2/ORU_R01.liquid
@@ -35,18 +35,18 @@
             {% assign fullEncounterId = encounterId | prepend: 'Encounter/' -%}
             {% include 'Resource/Encounter' PV1: firstSegments.PV1, PV2: firstSegments.PV2, ID: encounterId -%}
 
-            {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.3 -%}
-            {% if locationId -%}
-                {% include 'Resource/Location' PL: firstSegments.PV1.3, ID: locationId -%}
-                {% include 'Resource/Encounter' PV1: firstSegments.PV1, Location_ID_PV1_3: locationId, ID: encounterId -%}
+            {% evaluate locationId3 using 'ID/Location' PL: firstSegments.PV1.3 -%}
+            {% if locationId3 -%}
+                {% include 'Resource/Location' PL: firstSegments.PV1.3, ID: locationId3 -%}
             {% endif -%}
 
-            {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.6 -%}
-            {% if locationId -%}
-                {% include 'Resource/Location' PL: firstSegments.PV1.6, ID: locationId -%}
-                {% include 'Resource/Encounter' PV1: firstSegments.PV1, Location_ID_PV1_6: locationId, ID: encounterId -%}
+            {% evaluate locationId6 using 'ID/Location' PL: firstSegments.PV1.6 -%}
+            {% if locationId6 -%}
+                {% include 'Resource/Location' PL: firstSegments.PV1.6, ID: locationId6 -%}
             {% endif -%}
-            
+
+            {% include 'Resource/Encounter' PV1: firstSegments.PV1, Location_ID_PV1_3: locationId3, Location_ID_PV1_6: locationId6, ID: encounterId -%}
+
             {% if patientId -%}
                 {% include 'Reference/Encounter/Subject' ID: encounterId, REF: fullPatientId -%}
             {% endif -%}

--- a/data/Templates/Hl7v2/ORU_R01.liquid
+++ b/data/Templates/Hl7v2/ORU_R01.liquid
@@ -15,7 +15,7 @@
             {% include 'Resource/Patient' PID: firstSegments.PID, PD1: firstSegments.PD1, ID: patientId -%}
         {% endif -%}
 
-        {% evaluate provenanceId using 'ID/Provenance' MSH: firstSegments.MSH, baseID: patientId -%}
+        {% evaluate provenanceId using 'ID/Provenance' MSH: firstSegments.MSH, baseId: patientId -%}
         {% if provenanceId -%}
             {% include 'Resource/Provenance' MSH: firstSegments.MSH, ORC: firstSegments.ORC, ID: provenanceId -%}
         {% endif -%}
@@ -38,11 +38,13 @@
             {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.3 -%}
             {% if locationId -%}
                 {% include 'Resource/Location' PL: firstSegments.PV1.3, ID: locationId -%}
+                {% include 'Resource/Encounter' Location-ID-PV1-3: locationId, ID: encounterId -%}
             {% endif -%}
 
             {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.6 -%}
             {% if locationId -%}
                 {% include 'Resource/Location' PL: firstSegments.PV1.6, ID: locationId -%}
+                {% include 'Resource/Encounter' Location-ID-PV1-6: locationId, ID: encounterId -%}
             {% endif -%}
             
             {% if patientId -%}

--- a/data/Templates/Hl7v2/Resource/_Encounter.liquid
+++ b/data/Templates/Hl7v2/Resource/_Encounter.liquid
@@ -18,7 +18,7 @@
             {
                 "location":
                 {
-                    {% if PV1.3 -%}
+                    {% if Location_ID_PV1_3 -%}
                     "reference":"Location/{{ Location_ID_PV1_3 }}",
                     {% endif -%}
                 },
@@ -32,7 +32,7 @@
             {
                 "location":
                 {
-                    {% if PV1.6 -%}
+                    {% if Location_ID_PV1_6 -%}
                     "reference":"Location/{{ Location_ID_PV1_6 }}",
                     {% endif -%}
                 },

--- a/data/Templates/Hl7v2/Resource/_Encounter.liquid
+++ b/data/Templates/Hl7v2/Resource/_Encounter.liquid
@@ -19,7 +19,7 @@
                 "location":
                 {
                     {% if PV1.3 -%}
-                    "reference":"Location/{{ Location-ID-PV1-3 }}",
+                    "reference":"Location/{{ Location_ID_PV1_3 }}",
                     {% endif -%}
                 },
                 {% if PV1.2.1.Value != "P" -%}
@@ -33,7 +33,7 @@
                 "location":
                 {
                     {% if PV1.6 -%}
-                    "reference":"Location/{{ Location-ID-PV1-6 }}",
+                    "reference":"Location/{{ Location_ID_PV1_6 }}",
                     {% endif -%}
                 },
                 {% if PV1.6 -%}

--- a/data/Templates/Hl7v2/Resource/_Encounter.liquid
+++ b/data/Templates/Hl7v2/Resource/_Encounter.liquid
@@ -22,10 +22,10 @@
                     "reference":"Location/{{ Location_ID_PV1_3 }}",
                     {% endif -%}
                 },
-                {% if PV1.2.1.Value != "P" -%}
+                {% if PV1.2.1.Value != "P" and Location_ID_PV1_3 -%}
                 "status":"active",
                 {% endif -%}
-                {% if PV1.2.1.Value == "P" -%}
+                {% if PV1.2.1.Value == "P" and Location_ID_PV1_3 -%}
                 "status":"planned",
                 {% endif -%}
             },
@@ -36,7 +36,7 @@
                     "reference":"Location/{{ Location_ID_PV1_6 }}",
                     {% endif -%}
                 },
-                {% if PV1.6 -%}
+                {% if PV1.6 and Location_ID_PV1_6 -%}
                 "status":"completed",
                 {% endif -%}
             },

--- a/data/Templates/Hl7v2/Resource/_Encounter.liquid
+++ b/data/Templates/Hl7v2/Resource/_Encounter.liquid
@@ -19,7 +19,7 @@
                 "location":
                 {
                     {% if PV1.3 -%}
-                    "reference":"Location/{{generateUUID PV1-3}}",
+                    "reference":"Location/{{ Location-ID-PV1-3 }}",
                     {% endif -%}
                 },
                 {% if PV1.2.1.Value != "P" -%}
@@ -33,7 +33,7 @@
                 "location":
                 {
                     {% if PV1.6 -%}
-                    "reference":"Location/{{generateUUID PV1-6}}",
+                    "reference":"Location/{{ Location-ID-PV1-6 }}",
                     {% endif -%}
                 },
                 {% if PV1.6 -%}

--- a/data/Templates/Hl7v2/Resource/_Patient.liquid
+++ b/data/Templates/Hl7v2/Resource/_Patient.liquid
@@ -42,9 +42,11 @@
         ],
         "name":
         [
+            {% for p in PID.5.Repeats -%}
             {
-                {% include 'DataType/XPN' XPN: PID.5 -%}
+                {% include 'DataType/XPN' XPN: p -%}
             },
+            {% endfor -%}
             {
                 {% include 'DataType/XPN' XPN: PID.9 -%}
             },
@@ -53,9 +55,11 @@
         "gender":"{{ PID.8.Value | get_property: 'CodeSystem/Gender', 'code' }}",
         "address":
         [
+            {% for p in PID.11.Repeats -%}
             {
-                {% include 'DataType/XAD' XAD: PID.11 -%}
+                {% include 'DataType/XAD' XAD: p -%}
             },
+            {% endfor -%}
             {
                 "district":"{{ PID.12.Value }}",
             },

--- a/data/Templates/Hl7v2/Resource/_Patient.liquid
+++ b/data/Templates/Hl7v2/Resource/_Patient.liquid
@@ -42,11 +42,9 @@
         ],
         "name":
         [
-            {% for p in PID.5.Repeats -%}
             {
-                {% include 'DataType/XPN' XPN: p -%}
+                {% include 'DataType/XPN' XPN: PID.5 -%}
             },
-            {% endfor -%}
             {
                 {% include 'DataType/XPN' XPN: PID.9 -%}
             },
@@ -55,11 +53,9 @@
         "gender":"{{ PID.8.Value | get_property: 'CodeSystem/Gender', 'code' }}",
         "address":
         [
-            {% for p in PID.11.Repeats -%}
             {
-                {% include 'DataType/XAD' XAD: p -%}
+                {% include 'DataType/XAD' XAD: PID.11 -%}
             },
-            {% endfor -%}
             {
                 "district":"{{ PID.12.Value }}",
             },

--- a/data/Templates/Hl7v2/Resource/_PractitionerRole.liquid
+++ b/data/Templates/Hl7v2/Resource/_PractitionerRole.liquid
@@ -33,7 +33,7 @@
         "location":
         [
             {
-                {% if ROL.13 -%}
+                {% if Location_ID_ROL_13 -%}
                 "reference":"Location/{{ Location_ID_ROL_13 }}",
                 {% endif -%}
             },

--- a/data/Templates/Hl7v2/Resource/_PractitionerRole.liquid
+++ b/data/Templates/Hl7v2/Resource/_PractitionerRole.liquid
@@ -34,7 +34,7 @@
         [
             {
                 {% if ROL.13 -%}
-                "reference":"Location/{{ Location-ID-ROL-13 }}",
+                "reference":"Location/{{ Location_ID_ROL_13 }}",
                 {% endif -%}
             },
         ],

--- a/data/Templates/Hl7v2/Resource/_PractitionerRole.liquid
+++ b/data/Templates/Hl7v2/Resource/_PractitionerRole.liquid
@@ -34,7 +34,7 @@
         [
             {
                 {% if ROL.13 -%}
-                "reference":"Location/{{generateUUID ROL-13}}",
+                "reference":"Location/{{ Location-ID-ROL-13 }}",
                 {% endif -%}
             },
         ],

--- a/data/Templates/Hl7v2/Resource/_Procedure.liquid
+++ b/data/Templates/Hl7v2/Resource/_Procedure.liquid
@@ -39,7 +39,7 @@
         "location":
         {
             {% if PR1.23 -%}
-            "reference":"Location/{{generateUUID PR1-23}}",
+            "reference":"Location/{{ Location-ID-PR1-23 }}",
             {% endif -%}
         },
     },

--- a/data/Templates/Hl7v2/Resource/_Procedure.liquid
+++ b/data/Templates/Hl7v2/Resource/_Procedure.liquid
@@ -38,7 +38,7 @@
         ],
         "location":
         {
-            {% if PR1.23 -%}
+            {% if Location_ID_PR1_23 -%}
             "reference":"Location/{{ Location_ID_PR1_23 }}",
             {% endif -%}
         },

--- a/data/Templates/Hl7v2/Resource/_Procedure.liquid
+++ b/data/Templates/Hl7v2/Resource/_Procedure.liquid
@@ -39,7 +39,7 @@
         "location":
         {
             {% if PR1.23 -%}
-            "reference":"Location/{{ Location-ID-PR1-23 }}",
+            "reference":"Location/{{ Location_ID_PR1_23 }}",
             {% endif -%}
         },
     },

--- a/data/Templates/Hl7v2/VXU_V04.liquid
+++ b/data/Templates/Hl7v2/VXU_V04.liquid
@@ -15,7 +15,7 @@
             {% include 'Resource/Patient' PID: firstSegments.PID, PD1: firstSegments.PD1, ID: patientId -%}
         {% endif -%}
 
-        {% evaluate provenanceId using 'ID/Provenance' MSH: firstSegments.MSH, baseID: patientId -%}
+        {% evaluate provenanceId using 'ID/Provenance' MSH: firstSegments.MSH, baseId: patientId -%}
         {% if provenanceId -%}
             {% include 'Resource/Provenance' MSH: firstSegments.MSH, ORC: firstSegments.ORC, ID: provenanceId -%}
         {% endif -%}
@@ -37,11 +37,13 @@
             {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.3 -%}
             {% if locationId -%}
                 {% include 'Resource/Location' PL: firstSegments.PV1.3, ID: locationId -%}
+                {% include 'Resource/Encounter' Location-ID-PV1-3: locationId, ID: encounterId -%}
             {% endif -%}
 
             {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.6 -%}
             {% if locationId -%}
                 {% include 'Resource/Location' PL: firstSegments.PV1.6, ID: locationId -%}
+                {% include 'Resource/Encounter' Location-ID-PV1-6: locationId, ID: encounterId -%}
             {% endif -%}
             
             {% if patientId -%}

--- a/data/Templates/Hl7v2/VXU_V04.liquid
+++ b/data/Templates/Hl7v2/VXU_V04.liquid
@@ -37,13 +37,13 @@
             {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.3 -%}
             {% if locationId -%}
                 {% include 'Resource/Location' PL: firstSegments.PV1.3, ID: locationId -%}
-                {% include 'Resource/Encounter' Location-ID-PV1-3: locationId, ID: encounterId -%}
+                {% include 'Resource/Encounter' PV1: firstSegments.PV1, Location_ID_PV1_3: locationId, ID: encounterId -%}
             {% endif -%}
 
             {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.6 -%}
             {% if locationId -%}
                 {% include 'Resource/Location' PL: firstSegments.PV1.6, ID: locationId -%}
-                {% include 'Resource/Encounter' Location-ID-PV1-6: locationId, ID: encounterId -%}
+                {% include 'Resource/Encounter' PV1: firstSegments.PV1, Location_ID_PV1_6: locationId, ID: encounterId -%}
             {% endif -%}
             
             {% if patientId -%}

--- a/data/Templates/Hl7v2/VXU_V04.liquid
+++ b/data/Templates/Hl7v2/VXU_V04.liquid
@@ -34,17 +34,17 @@
         {% if encounterId -%}
             {% include 'Resource/Encounter' PV1: firstSegments.PV1, ID: encounterId -%}
 
-            {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.3 -%}
-            {% if locationId -%}
-                {% include 'Resource/Location' PL: firstSegments.PV1.3, ID: locationId -%}
-                {% include 'Resource/Encounter' PV1: firstSegments.PV1, Location_ID_PV1_3: locationId, ID: encounterId -%}
+            {% evaluate locationId3 using 'ID/Location' PL: firstSegments.PV1.3 -%}
+            {% if locationId3 -%}
+                {% include 'Resource/Location' PL: firstSegments.PV1.3, ID: locationId3 -%}
             {% endif -%}
 
-            {% evaluate locationId using 'ID/Location' PL: firstSegments.PV1.6 -%}
-            {% if locationId -%}
-                {% include 'Resource/Location' PL: firstSegments.PV1.6, ID: locationId -%}
-                {% include 'Resource/Encounter' PV1: firstSegments.PV1, Location_ID_PV1_6: locationId, ID: encounterId -%}
+            {% evaluate locationId6 using 'ID/Location' PL: firstSegments.PV1.6 -%}
+            {% if locationId6 -%}
+                {% include 'Resource/Location' PL: firstSegments.PV1.6, ID: locationId6 -%}
             {% endif -%}
+
+            {% include 'Resource/Encounter' PV1: firstSegments.PV1, Location_ID_PV1_3: locationId3, Location_ID_PV1_6: locationId6, ID: encounterId -%}
             
             {% if patientId -%}
                 {% include 'Reference/Encounter/Subject' ID: encounterId, REF: fullPatientId -%}

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT01-23-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT01-23-expected.json
@@ -132,10 +132,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:8530bde1-9b03-3292-264e-9b305cf30b37",
+      "fullUrl": "urn:uuid:b5aae309-4caf-c2cd-b087-0fd6db6dd058",
       "resource": {
         "resourceType": "Provenance",
-        "id": "8530bde1-9b03-3292-264e-9b305cf30b37",
+        "id": "b5aae309-4caf-c2cd-b087-0fd6db6dd058",
         "agent": [
           {
             "type": {
@@ -152,7 +152,7 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Provenance/8530bde1-9b03-3292-264e-9b305cf30b37"
+        "url": "Provenance/b5aae309-4caf-c2cd-b087-0fd6db6dd058"
       }
     },
     {
@@ -195,6 +195,9 @@
             "location": {
               "reference": "Location/"
             },
+            "status": "active"
+          },
+          {
             "status": "active"
           }
         ],

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT01-23-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT01-23-expected.json
@@ -192,9 +192,6 @@
         "status": "unknown",
         "location": [
           {
-            "status": "active"
-          },
-          {
             "location": {
               "reference": "Location/9b2956e2-230b-9dd5-ad8d-0e697a8664c1"
             },

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT01-23-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT01-23-expected.json
@@ -192,9 +192,6 @@
         "status": "unknown",
         "location": [
           {
-            "location": {
-              "reference": "Location/"
-            },
             "status": "active"
           },
           {

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT01-23-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT01-23-expected.json
@@ -198,6 +198,9 @@
             "status": "active"
           },
           {
+            "location": {
+              "reference": "Location/9b2956e2-230b-9dd5-ad8d-0e697a8664c1"
+            },
             "status": "active"
           }
         ],

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT01-28-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT01-28-expected.json
@@ -157,10 +157,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:8b872c00-30c9-392b-a5ca-ba6176cd7f75",
+      "fullUrl": "urn:uuid:a6091df2-6411-bec2-7f42-36d851d96cbe",
       "resource": {
         "resourceType": "Provenance",
-        "id": "8b872c00-30c9-392b-a5ca-ba6176cd7f75",
+        "id": "a6091df2-6411-bec2-7f42-36d851d96cbe",
         "agent": [
           {
             "type": {
@@ -177,7 +177,7 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Provenance/8b872c00-30c9-392b-a5ca-ba6176cd7f75"
+        "url": "Provenance/a6091df2-6411-bec2-7f42-36d851d96cbe"
       }
     },
     {
@@ -241,6 +241,9 @@
             "location": {
               "reference": "Location/"
             },
+            "status": "active"
+          },
+          {
             "status": "active"
           }
         ],

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT01-28-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT01-28-expected.json
@@ -244,6 +244,9 @@
             "status": "active"
           },
           {
+            "location": {
+              "reference": "Location/29eb5214-21d0-ed82-39f9-da4e50277c80"
+            },
             "status": "active"
           }
         ],

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT01-28-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT01-28-expected.json
@@ -238,9 +238,6 @@
         "status": "unknown",
         "location": [
           {
-            "status": "active"
-          },
-          {
             "location": {
               "reference": "Location/29eb5214-21d0-ed82-39f9-da4e50277c80"
             },

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT01-28-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT01-28-expected.json
@@ -238,9 +238,6 @@
         "status": "unknown",
         "location": [
           {
-            "location": {
-              "reference": "Location/"
-            },
             "status": "active"
           },
           {

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-23-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-23-expected.json
@@ -235,15 +235,9 @@
         "status": "unknown",
         "location": [
           {
-            "location": {
-              "reference": "Location/"
-            },
             "status": "active"
           },
           {
-            "location": {
-              "reference": "Location/"
-            },
             "status": "completed"
           },
           {

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-23-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-23-expected.json
@@ -3,10 +3,10 @@
   "type": "transaction",
   "entry": [
     {
-      "fullUrl": "urn:uuid:18548d54-14a8-815a-c1bb-396f35b37164",
+      "fullUrl": "urn:uuid:",
       "resource": {
         "resourceType": "MessageHeader",
-        "id": "18548d54-14a8-815a-c1bb-396f35b37164",
+        "id": "",
         "source": {
           "source": {
             "name": "NES"
@@ -38,14 +38,14 @@
       },
       "request": {
         "method": "PUT",
-        "url": "MessageHeader/18548d54-14a8-815a-c1bb-396f35b37164"
+        "url": "MessageHeader/"
       }
     },
     {
-      "fullUrl": "urn:uuid:5002eb07-c460-7112-6574-50303ae3b4a6",
+      "fullUrl": "urn:uuid:",
       "resource": {
         "resourceType": "Patient",
-        "id": "5002eb07-c460-7112-6574-50303ae3b4a6",
+        "id": "",
         "identifier": [
           {
             "value": "123456789",
@@ -158,14 +158,14 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Patient/5002eb07-c460-7112-6574-50303ae3b4a6"
+        "url": "Patient/"
       }
     },
     {
-      "fullUrl": "urn:uuid:ab3d28cb-c909-4ba2-b02e-0a868895ef0b",
+      "fullUrl": "urn:uuid:",
       "resource": {
         "resourceType": "Provenance",
-        "id": "ab3d28cb-c909-4ba2-b02e-0a868895ef0b",
+        "id": "",
         "agent": [
           {
             "type": {
@@ -182,14 +182,14 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Provenance/ab3d28cb-c909-4ba2-b02e-0a868895ef0b"
+        "url": "Provenance/"
       }
     },
     {
-      "fullUrl": "urn:uuid:0b931b2e-4814-b7ed-7159-4cf2805ef38f",
+      "fullUrl": "urn:uuid:",
       "resource": {
         "resourceType": "Account",
-        "id": "0b931b2e-4814-b7ed-7159-4cf2805ef38f",
+        "id": "",
         "identifier": [
           {
             "value": "12345678"
@@ -198,14 +198,14 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Account/0b931b2e-4814-b7ed-7159-4cf2805ef38f"
+        "url": "Account/"
       }
     },
     {
-      "fullUrl": "urn:uuid:ff939fb2-65de-0b68-4a81-ce9cd8e6f5a5",
+      "fullUrl": "urn:uuid:",
       "resource": {
         "resourceType": "Organization",
-        "id": "ff939fb2-65de-0b68-4a81-ce9cd8e6f5a5",
+        "id": "",
         "identifier": [
           {
             "value": "NINTENDO"
@@ -219,14 +219,14 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Organization/ff939fb2-65de-0b68-4a81-ce9cd8e6f5a5"
+        "url": "Organization/"
       }
     },
     {
-      "fullUrl": "urn:uuid:1ffe7bbb-44ca-d195-1456-40d94950090b",
+      "fullUrl": "urn:uuid:",
       "resource": {
         "resourceType": "Encounter",
-        "id": "1ffe7bbb-44ca-d195-1456-40d94950090b",
+        "id": "",
         "class": {
           "code": "AMB",
           "display": "ambulatory",
@@ -247,7 +247,16 @@
             "status": "completed"
           },
           {
+            "location": {
+              "reference": "Location/"
+            },
             "status": "active"
+          },
+          {
+            "location": {
+              "reference": "Location/"
+            },
+            "status": "completed"
           }
         ],
         "participant": [
@@ -315,19 +324,19 @@
           "start": "2001-01-01T00:00:00Z"
         },
         "subject": {
-          "reference": "Patient/5002eb07-c460-7112-6574-50303ae3b4a6"
+          "reference": "Patient/"
         }
       },
       "request": {
         "method": "PUT",
-        "url": "Encounter/1ffe7bbb-44ca-d195-1456-40d94950090b"
+        "url": "Encounter/"
       }
     },
     {
-      "fullUrl": "urn:uuid:1061dd71-d0a8-e8d0-7468-5be2eb4db1f8",
+      "fullUrl": "urn:uuid:",
       "resource": {
         "resourceType": "Location",
-        "id": "1061dd71-d0a8-e8d0-7468-5be2eb4db1f8",
+        "id": "",
         "mode": "instance",
         "physicalType": {
           "coding": [
@@ -339,25 +348,25 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Location/1061dd71-d0a8-e8d0-7468-5be2eb4db1f8"
+        "url": "Location/"
       }
     },
     {
-      "fullUrl": "urn:uuid:affd96b8-87bc-956b-0215-7db7a8c6a9b3",
+      "fullUrl": "urn:uuid:",
       "resource": {
         "resourceType": "Location",
-        "id": "affd96b8-87bc-956b-0215-7db7a8c6a9b3"
+        "id": ""
       },
       "request": {
         "method": "PUT",
-        "url": "Location/affd96b8-87bc-956b-0215-7db7a8c6a9b3"
+        "url": "Location/"
       }
     },
     {
-      "fullUrl": "urn:uuid:4e083e5f-53b4-194d-b6bd-6d51b5dab850",
+      "fullUrl": "urn:uuid:",
       "resource": {
         "resourceType": "RelatedPerson",
-        "id": "4e083e5f-53b4-194d-b6bd-6d51b5dab850",
+        "id": "",
         "address": [
           {
             "line": [
@@ -386,19 +395,19 @@
           }
         ],
         "patient": {
-          "reference": "Patient/5002eb07-c460-7112-6574-50303ae3b4a6"
+          "reference": "Patient/"
         }
       },
       "request": {
         "method": "PUT",
-        "url": "RelatedPerson/4e083e5f-53b4-194d-b6bd-6d51b5dab850"
+        "url": "RelatedPerson/"
       }
     },
     {
-      "fullUrl": "urn:uuid:a7a01053-59be-eb80-1f54-591a69d5bc8e",
+      "fullUrl": "urn:uuid:",
       "resource": {
         "resourceType": "RelatedPerson",
-        "id": "a7a01053-59be-eb80-1f54-591a69d5bc8e",
+        "id": "",
         "relationship": [
           {
             "coding": [
@@ -438,12 +447,12 @@
           }
         ],
         "patient": {
-          "reference": "Patient/5002eb07-c460-7112-6574-50303ae3b4a6"
+          "reference": "Patient/"
         }
       },
       "request": {
         "method": "PUT",
-        "url": "RelatedPerson/a7a01053-59be-eb80-1f54-591a69d5bc8e"
+        "url": "RelatedPerson/"
       }
     }
   ]

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-23-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-23-expected.json
@@ -235,12 +235,6 @@
         "status": "unknown",
         "location": [
           {
-            "status": "active"
-          },
-          {
-            "status": "completed"
-          },
-          {
             "location": {
               "reference": "Location/1061dd71-d0a8-e8d0-7468-5be2eb4db1f8"
             },

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-23-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-23-expected.json
@@ -3,10 +3,10 @@
   "type": "transaction",
   "entry": [
     {
-      "fullUrl": "urn:uuid:",
+      "fullUrl": "urn:uuid:18548d54-14a8-815a-c1bb-396f35b37164",
       "resource": {
         "resourceType": "MessageHeader",
-        "id": "",
+        "id": "18548d54-14a8-815a-c1bb-396f35b37164",
         "source": {
           "source": {
             "name": "NES"
@@ -38,14 +38,14 @@
       },
       "request": {
         "method": "PUT",
-        "url": "MessageHeader/"
+        "url": "MessageHeader/18548d54-14a8-815a-c1bb-396f35b37164"
       }
     },
     {
-      "fullUrl": "urn:uuid:",
+      "fullUrl": "urn:uuid:5002eb07-c460-7112-6574-50303ae3b4a6",
       "resource": {
         "resourceType": "Patient",
-        "id": "",
+        "id": "5002eb07-c460-7112-6574-50303ae3b4a6",
         "identifier": [
           {
             "value": "123456789",
@@ -158,14 +158,14 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Patient/"
+        "url": "Patient/5002eb07-c460-7112-6574-50303ae3b4a6"
       }
     },
     {
-      "fullUrl": "urn:uuid:",
+      "fullUrl": "urn:uuid:ab3d28cb-c909-4ba2-b02e-0a868895ef0b",
       "resource": {
         "resourceType": "Provenance",
-        "id": "",
+        "id": "ab3d28cb-c909-4ba2-b02e-0a868895ef0b",
         "agent": [
           {
             "type": {
@@ -182,14 +182,14 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Provenance/"
+        "url": "Provenance/ab3d28cb-c909-4ba2-b02e-0a868895ef0b"
       }
     },
     {
-      "fullUrl": "urn:uuid:",
+      "fullUrl": "urn:uuid:0b931b2e-4814-b7ed-7159-4cf2805ef38f",
       "resource": {
         "resourceType": "Account",
-        "id": "",
+        "id": "0b931b2e-4814-b7ed-7159-4cf2805ef38f",
         "identifier": [
           {
             "value": "12345678"
@@ -198,14 +198,14 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Account/"
+        "url": "Account/0b931b2e-4814-b7ed-7159-4cf2805ef38f"
       }
     },
     {
-      "fullUrl": "urn:uuid:",
+      "fullUrl": "urn:uuid:ff939fb2-65de-0b68-4a81-ce9cd8e6f5a5",
       "resource": {
         "resourceType": "Organization",
-        "id": "",
+        "id": "ff939fb2-65de-0b68-4a81-ce9cd8e6f5a5",
         "identifier": [
           {
             "value": "NINTENDO"
@@ -219,14 +219,14 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Organization/"
+        "url": "Organization/ff939fb2-65de-0b68-4a81-ce9cd8e6f5a5"
       }
     },
     {
-      "fullUrl": "urn:uuid:",
+      "fullUrl": "urn:uuid:1ffe7bbb-44ca-d195-1456-40d94950090b",
       "resource": {
         "resourceType": "Encounter",
-        "id": "",
+        "id": "1ffe7bbb-44ca-d195-1456-40d94950090b",
         "class": {
           "code": "AMB",
           "display": "ambulatory",
@@ -248,13 +248,13 @@
           },
           {
             "location": {
-              "reference": "Location/"
+              "reference": "Location/1061dd71-d0a8-e8d0-7468-5be2eb4db1f8"
             },
             "status": "active"
           },
           {
             "location": {
-              "reference": "Location/"
+              "reference": "Location/affd96b8-87bc-956b-0215-7db7a8c6a9b3"
             },
             "status": "completed"
           }
@@ -324,19 +324,19 @@
           "start": "2001-01-01T00:00:00Z"
         },
         "subject": {
-          "reference": "Patient/"
+          "reference": "Patient/5002eb07-c460-7112-6574-50303ae3b4a6"
         }
       },
       "request": {
         "method": "PUT",
-        "url": "Encounter/"
+        "url": "Encounter/1ffe7bbb-44ca-d195-1456-40d94950090b"
       }
     },
     {
-      "fullUrl": "urn:uuid:",
+      "fullUrl": "urn:uuid:1061dd71-d0a8-e8d0-7468-5be2eb4db1f8",
       "resource": {
         "resourceType": "Location",
-        "id": "",
+        "id": "1061dd71-d0a8-e8d0-7468-5be2eb4db1f8",
         "mode": "instance",
         "physicalType": {
           "coding": [
@@ -348,25 +348,25 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Location/"
+        "url": "Location/1061dd71-d0a8-e8d0-7468-5be2eb4db1f8"
       }
     },
     {
-      "fullUrl": "urn:uuid:",
+      "fullUrl": "urn:uuid:affd96b8-87bc-956b-0215-7db7a8c6a9b3",
       "resource": {
         "resourceType": "Location",
-        "id": ""
+        "id": "affd96b8-87bc-956b-0215-7db7a8c6a9b3"
       },
       "request": {
         "method": "PUT",
-        "url": "Location/"
+        "url": "Location/affd96b8-87bc-956b-0215-7db7a8c6a9b3"
       }
     },
     {
-      "fullUrl": "urn:uuid:",
+      "fullUrl": "urn:uuid:4e083e5f-53b4-194d-b6bd-6d51b5dab850",
       "resource": {
         "resourceType": "RelatedPerson",
-        "id": "",
+        "id": "4e083e5f-53b4-194d-b6bd-6d51b5dab850",
         "address": [
           {
             "line": [
@@ -395,19 +395,19 @@
           }
         ],
         "patient": {
-          "reference": "Patient/"
+          "reference": "Patient/5002eb07-c460-7112-6574-50303ae3b4a6"
         }
       },
       "request": {
         "method": "PUT",
-        "url": "RelatedPerson/"
+        "url": "RelatedPerson/4e083e5f-53b4-194d-b6bd-6d51b5dab850"
       }
     },
     {
-      "fullUrl": "urn:uuid:",
+      "fullUrl": "urn:uuid:a7a01053-59be-eb80-1f54-591a69d5bc8e",
       "resource": {
         "resourceType": "RelatedPerson",
-        "id": "",
+        "id": "a7a01053-59be-eb80-1f54-591a69d5bc8e",
         "relationship": [
           {
             "coding": [
@@ -447,12 +447,12 @@
           }
         ],
         "patient": {
-          "reference": "Patient/"
+          "reference": "Patient/5002eb07-c460-7112-6574-50303ae3b4a6"
         }
       },
       "request": {
         "method": "PUT",
-        "url": "RelatedPerson/"
+        "url": "RelatedPerson/a7a01053-59be-eb80-1f54-591a69d5bc8e"
       }
     }
   ]

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-23-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-23-expected.json
@@ -162,10 +162,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:dd338e52-023d-44ac-5ede-c7f279ec6829",
+      "fullUrl": "urn:uuid:ab3d28cb-c909-4ba2-b02e-0a868895ef0b",
       "resource": {
         "resourceType": "Provenance",
-        "id": "dd338e52-023d-44ac-5ede-c7f279ec6829",
+        "id": "ab3d28cb-c909-4ba2-b02e-0a868895ef0b",
         "agent": [
           {
             "type": {
@@ -182,7 +182,7 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Provenance/dd338e52-023d-44ac-5ede-c7f279ec6829"
+        "url": "Provenance/ab3d28cb-c909-4ba2-b02e-0a868895ef0b"
       }
     },
     {
@@ -245,6 +245,9 @@
               "reference": "Location/"
             },
             "status": "completed"
+          },
+          {
+            "status": "active"
           }
         ],
         "participant": [

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-251-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-251-expected.json
@@ -132,11 +132,6 @@
           "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode"
         },
         "status": "unknown",
-        "location": [
-          {
-            "status": "active"
-          }
-        ],
         "participant": [
           {
             "type": [

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-28-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-28-expected.json
@@ -180,6 +180,9 @@
             "status": "active"
           },
           {
+            "location": {
+              "reference": "Location/a821376a-5d7b-7274-8d95-a3f7c7efaf1b"
+            },
             "status": "active"
           }
         ],

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-28-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-28-expected.json
@@ -122,10 +122,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:27610aa3-9d40-71d4-90ad-3feaff4411c7",
+      "fullUrl": "urn:uuid:a81dc37f-d7f3-c46a-00b1-4ff08fa99061",
       "resource": {
         "resourceType": "Provenance",
-        "id": "27610aa3-9d40-71d4-90ad-3feaff4411c7",
+        "id": "a81dc37f-d7f3-c46a-00b1-4ff08fa99061",
         "agent": [
           {
             "type": {
@@ -142,14 +142,14 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Provenance/27610aa3-9d40-71d4-90ad-3feaff4411c7"
+        "url": "Provenance/a81dc37f-d7f3-c46a-00b1-4ff08fa99061"
       }
     },
     {
-      "fullUrl": "urn:uuid:9ec7ccd5-cb9a-0a30-eb47-1755ff8f9f7c",
+      "fullUrl": "urn:uuid:256cf56f-8ec4-5af5-cf3f-4f9a833482be",
       "resource": {
         "resourceType": "Account",
-        "id": "9ec7ccd5-cb9a-0a30-eb47-1755ff8f9f7c",
+        "id": "256cf56f-8ec4-5af5-cf3f-4f9a833482be",
         "identifier": [
           {
             "value": "1234"
@@ -158,7 +158,7 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Account/9ec7ccd5-cb9a-0a30-eb47-1755ff8f9f7c"
+        "url": "Account/256cf56f-8ec4-5af5-cf3f-4f9a833482be"
       }
     },
     {
@@ -177,6 +177,9 @@
             "location": {
               "reference": "Location/"
             },
+            "status": "active"
+          },
+          {
             "status": "active"
           }
         ],

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-28-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-28-expected.json
@@ -174,9 +174,6 @@
         "status": "unknown",
         "location": [
           {
-            "status": "active"
-          },
-          {
             "location": {
               "reference": "Location/a821376a-5d7b-7274-8d95-a3f7c7efaf1b"
             },

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-28-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-28-expected.json
@@ -174,9 +174,6 @@
         "status": "unknown",
         "location": [
           {
-            "location": {
-              "reference": "Location/"
-            },
             "status": "active"
           },
           {


### PR DESCRIPTION
* All changed resource templates: `Encounter`, `PractitionerRole` and `Procedure`.
* All main templates are changed.
* Changed the ID from `generateUUID ...` to a ID variable passed by the invoker(usually the main templates).
* Changed the main templates to pass the referred ID.
* BTW, the reason why we directly set reference attributes inside resource templates instead of invoking `include Reference/.../...` is that if a resource has multiple reference attributes with the same type, there will be no way to tell them, like `PV1-3, Location.Reference` and `PV1-6, Location.Reference`.