### PR TITLE
Fixed trace info indexing issue for MSH segments while generating unused segments

### DIFF
--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Models/Hl7v2TraceInfoTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Models/Hl7v2TraceInfoTests.cs
@@ -51,6 +51,11 @@ PID|1||10006579^^^1^MR^1||DUCK^DONALD^D||19241010|M||1|111 DUCK ST^^FOWL^CA^9999
             Assert.Equal(2, traceInfo.UnusedSegments.Count);
             Assert.Equal(27, traceInfo.UnusedSegments[1].Components.Count);
 
+            // Specially test MSH unused segments
+            Assert.Equal(9, traceInfo.UnusedSegments[0].Components[0].Start);
+            Assert.Equal("AccMgr", traceInfo.UnusedSegments[0].Components[0].Value);
+            Assert.Equal(15, traceInfo.UnusedSegments[0].Components[0].End);
+
             // Valid Hl7v2Data after render
             var processor = new Hl7v2Processor();
             var templateProvider = new Hl7v2TemplateProvider(Constants.Hl7v2TemplateDirectory);

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Models/Hl7v2TraceInfo.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Models/Hl7v2TraceInfo.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2.Models
 
         private static int FindOffsetInSegment(string segmentHeader, string segmentValue, Hl7v2EncodingCharacters encodingCharacters, int fieldIndex, int componentIndex)
         {
-            // All values($segmentValue and $fieldValue) need to be unescaped firstly (from "\\T" to "\T"),
+            // All values($segmentValue and $fieldValue) need to be unescaped firstly (from "\" to "\\"),
             // or the length will be incorrectly calculated
             segmentValue = SpecialCharProcessor.Unescape(segmentValue);
 

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Models/Hl7v2TraceInfo.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Models/Hl7v2TraceInfo.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Health.Fhir.Liquid.Converter.Exceptions;
 using Microsoft.Health.Fhir.Liquid.Converter.Extensions;
+using Microsoft.Health.Fhir.Liquid.Converter.Hl7v2.InputProcessor;
 using Microsoft.Health.Fhir.Liquid.Converter.Models;
 
 namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2.Models
@@ -31,20 +32,16 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2.Models
             {
                 for (var i = 0; i < hl7v2Data?.Data?.Count; ++i)
                 {
+                    var segmentHeader = hl7v2Data.Meta[i];
                     var segment = hl7v2Data.Data[i];
                     var unusedSegment = new UnusedHl7v2Segment(i);
+                    unusedSegment.Type = segmentHeader;
+
                     for (var j = 0; j < segment?.Fields?.Count; ++j)
                     {
-                        // Encoding characters field is treated as accessed
-                        if (i == 0 && j == 1)
+                        // Field separator and encoding characters field are treated as accessed
+                        if (i == 0 && j <= 2)
                         {
-                            continue;
-                        }
-
-                        // Segment id field is treated as accessed
-                        if (j == 0 && segment.Fields[j] is Hl7v2Field segmentIdField)
-                        {
-                            unusedSegment.Type = segmentIdField.Value;
                             continue;
                         }
 
@@ -55,7 +52,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2.Models
                             {
                                 if (field.Components[k] is Hl7v2Component component && component.IsAccessed == false)
                                 {
-                                    var indexInSegment = FindOffsetInSegment(segment.Value, hl7v2Data.EncodingCharacters, j, k - 1);
+                                    var indexInSegment = FindOffsetInSegment(segmentHeader, segment.Value, hl7v2Data.EncodingCharacters, j, k - 1);
                                     var unusedComponent = new UnusedHl7v2Component(indexInSegment, indexInSegment + component.Value.Length, component.Value);
                                     unusedComponents.Add(unusedComponent);
                                 }
@@ -82,8 +79,18 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2.Models
             return new Hl7v2TraceInfo(unusedSegments);
         }
 
-        private static int FindOffsetInSegment(string segmentValue, Hl7v2EncodingCharacters encodingCharacters, int fieldIndex, int componentIndex)
+        private static int FindOffsetInSegment(string segmentHeader, string segmentValue, Hl7v2EncodingCharacters encodingCharacters, int fieldIndex, int componentIndex)
         {
+            // All values($segmentValue and $fieldValue) need to be unescaped firstly (from "\\T" to "\T"),
+            // or the length will be incorrectly calculated
+            segmentValue = SpecialCharProcessor.Unescape(segmentValue);
+
+            // MSH segment should be treated separately since the first '|' in MSH segment is a special field
+            if (segmentHeader == "MSH")
+            {
+                fieldIndex--;
+            }
+
             var startFieldIndex = segmentValue.IndexOfNthOccurrence(encodingCharacters.FieldSeparator, fieldIndex) + 1;
             var endFieldIndex = segmentValue.IndexOfNthOccurrence(encodingCharacters.FieldSeparator, fieldIndex + 1);
             if (endFieldIndex == -1)
@@ -91,7 +98,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2.Models
                 endFieldIndex = segmentValue.Length;
             }
 
-            var fieldValue = segmentValue.Substring(startFieldIndex, endFieldIndex - startFieldIndex);
+            var fieldValue = SpecialCharProcessor.Unescape(segmentValue.Substring(startFieldIndex, endFieldIndex - startFieldIndex));
             return startFieldIndex + fieldValue.IndexOfNthOccurrence(encodingCharacters.ComponentSeparator, componentIndex) + 1;
         }
     }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Models/Hl7v2TraceInfo.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Models/Hl7v2TraceInfo.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2.Models
 
         private static int FindOffsetInSegment(string segmentHeader, string segmentValue, Hl7v2EncodingCharacters encodingCharacters, int fieldIndex, int componentIndex)
         {
-            // All values($segmentValue and $fieldValue) need to be unescaped firstly (from "\" to "\\"),
+            // All values($segmentValue and $fieldValue) need to be unescaped firstly (from "\\" back to "\"),
             // or the length will be incorrectly calculated
             segmentValue = SpecialCharProcessor.Unescape(segmentValue);
 

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Models/Hl7v2TraceInfo.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Models/Hl7v2TraceInfo.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2.Models
             segmentValue = SpecialCharProcessor.Unescape(segmentValue);
 
             // MSH segment should be treated separately since the first '|' in MSH segment is a special field
-            if (segmentHeader == "MSH")
+            if (segmentHeader.Equals("MSH"))
             {
                 fieldIndex--;
             }


### PR DESCRIPTION
* MSH segments should be treated separately 'cause the first `|` is a special field, which caused incorrect indexing.
* Updated related test cases.

Well, we can't put the grammar escaping in post processing phase 'cause the `rawResult` contains tons of `"` to constrcut JSON result, the grammar escaping will mistakenly escape them, which causes error.
And we can't put the semantical unescaping in post processing phase 'cause the semantical unescaping must be done before grammar escaping, or some semantically escaped content(`\T\`, \E\) will be mistakenly grammar escaped(to `\\T\\`, `\\E\\`).

So we currently can only keep the semantical unescaping and grammar escaping in `NormalizeText`, and let the indexing offset by some spaces if the origin message contains semantically escapped characters(like `\T\`).