### PR TITLE
Change resource bundle type from 'transaction' to 'batch'

### DIFF
--- a/data/Templates/Hl7v2/ADT_A01.liquid
+++ b/data/Templates/Hl7v2/ADT_A01.liquid
@@ -1,6 +1,6 @@
 ﻿{
     "resourceType": "Bundle",
-    "type": "transaction",
+    "type": "batch",
     "entry": [
         {% assign firstSegments = hl7v2Data | get_first_segments: 'PID|PD1|PV1|PV2|AVR|MSH' -%}
 

--- a/data/Templates/Hl7v2/OML_O21.liquid
+++ b/data/Templates/Hl7v2/OML_O21.liquid
@@ -1,6 +1,6 @@
 ﻿{
     "resourceType": "Bundle",
-    "type": "transaction",
+    "type": "batch",
     "entry": [
         {% assign firstSegments = hl7v2Data | get_first_segments: 'PID|PD1|PV1|PV2|ORC|MSH' -%}
 

--- a/data/Templates/Hl7v2/ORU_R01.liquid
+++ b/data/Templates/Hl7v2/ORU_R01.liquid
@@ -1,6 +1,6 @@
 ﻿{
     "resourceType": "Bundle",
-    "type": "transaction",
+    "type": "batch",
     "entry": [
         {% assign firstSegments = hl7v2Data | get_first_segments: 'PID|PD1|NK1|PV1|PV2|MSH' -%}
 

--- a/data/Templates/Hl7v2/VXU_V04.liquid
+++ b/data/Templates/Hl7v2/VXU_V04.liquid
@@ -1,6 +1,6 @@
 ﻿{
     "resourceType": "Bundle",
-    "type": "transaction",
+    "type": "batch",
     "entry": [
         {% assign firstSegments = hl7v2Data | get_first_segments: 'PID|PD1|PV1|ORC|MSH' -%}
 

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT01-23-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT01-23-expected.json
@@ -1,6 +1,6 @@
 ﻿{
   "resourceType": "Bundle",
-  "type": "transaction",
+  "type": "batch",
   "entry": [
     {
       "fullUrl": "urn:uuid:d3171c25-5db7-e705-140c-19d0972f1ba2",

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT01-28-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT01-28-expected.json
@@ -1,6 +1,6 @@
 ﻿{
   "resourceType": "Bundle",
-  "type": "transaction",
+  "type": "batch",
   "entry": [
     {
       "fullUrl": "urn:uuid:64c2d51b-34a4-e841-fb1c-03f1f7762d1a",

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-23-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-23-expected.json
@@ -1,6 +1,6 @@
 ﻿{
   "resourceType": "Bundle",
-  "type": "transaction",
+  "type": "batch",
   "entry": [
     {
       "fullUrl": "urn:uuid:18548d54-14a8-815a-c1bb-396f35b37164",

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-251-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-251-expected.json
@@ -1,6 +1,6 @@
 ﻿{
   "resourceType": "Bundle",
-  "type": "transaction",
+  "type": "batch",
   "entry": [
     {
       "fullUrl": "urn:uuid:7393bcca-6d2f-543d-7787-0753133a8496",

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-28-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ADT_A01/ADT04-28-expected.json
@@ -1,6 +1,6 @@
 ﻿{
   "resourceType": "Bundle",
-  "type": "transaction",
+  "type": "batch",
   "entry": [
     {
       "fullUrl": "urn:uuid:aa9b0327-0d9f-945a-888c-07658da974df",

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/OML_O21/MDHHS-OML-O21-1-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/OML_O21/MDHHS-OML-O21-1-expected.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "Bundle",
-  "type": "transaction",
+  "type": "batch",
   "entry": [
     {
       "fullUrl": "urn:uuid:6eda7d2f-32f8-a6c7-5125-d59f65a25c97",

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/OML_O21/MDHHS-OML-O21-2-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/OML_O21/MDHHS-OML-O21-2-expected.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "Bundle",
-  "type": "transaction",
+  "type": "batch",
   "entry": [
     {
       "fullUrl": "urn:uuid:f651f710-5269-afaa-f743-57b7a501b0c6",

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ORU_R01/LAB-ORU-1-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ORU_R01/LAB-ORU-1-expected.json
@@ -1,6 +1,6 @@
 ﻿{
   "resourceType": "Bundle",
-  "type": "transaction",
+  "type": "batch",
   "entry": [
     {
       "fullUrl": "urn:uuid:1a1787ae-e880-227d-1d8e-6167130b9a66",

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ORU_R01/LAB-ORU-2-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ORU_R01/LAB-ORU-2-expected.json
@@ -1,6 +1,6 @@
 ﻿{
   "resourceType": "Bundle",
-  "type": "transaction",
+  "type": "batch",
   "entry": [
     {
       "fullUrl": "urn:uuid:9a62ebb2-108d-3a93-9edf-18645610f536",

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ORU_R01/LRI_2.0-NG_CBC_Typ_Message-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ORU_R01/LRI_2.0-NG_CBC_Typ_Message-expected.json
@@ -1,6 +1,6 @@
 ﻿{
   "resourceType": "Bundle",
-  "type": "transaction",
+  "type": "batch",
   "entry": [
     {
       "fullUrl": "urn:uuid:15cde54f-eadb-4bee-fe4c-0e8dbe4f4959",

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ORU_R01/ORU-R01-RMGEAD-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/ORU_R01/ORU-R01-RMGEAD-expected.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "Bundle",
-  "type": "transaction",
+  "type": "batch",
   "entry": [
     {
       "fullUrl": "urn:uuid:59137ac2-b595-49c0-863e-df25b62bf2cd",

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/VXU_V04/IZ_1_1.1_Admin_Child_Max_Message-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/VXU_V04/IZ_1_1.1_Admin_Child_Max_Message-expected.json
@@ -1,6 +1,6 @@
 ﻿{
   "resourceType": "Bundle",
-  "type": "transaction",
+  "type": "batch",
   "entry": [
     {
       "fullUrl": "urn:uuid:5cddb2d1-c441-ec21-1c0c-96605dd3a9c0",

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/VXU_V04/VXU-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/VXU_V04/VXU-expected.json
@@ -1,6 +1,6 @@
 ﻿{
   "resourceType": "Bundle",
-  "type": "transaction",
+  "type": "batch",
   "entry": [
     {
       "fullUrl": "urn:uuid:aefd5bbc-563b-7d19-5096-4b5754c338c1",


### PR DESCRIPTION
* Change the templates so that the default bundle type is 'batch' instead of 'transaction' because our FHIR servers do not support 'transaction' yet.