### PR TITLE
Add retry when pull template from ACR for FHIR server.

### DIFF
--- a/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/Client/ACRClientTests.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/Client/ACRClientTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Microsoft.Azure.ContainerRegistry;
 using Microsoft.Azure.ContainerRegistry.Models;
 using Microsoft.Health.Fhir.TemplateManagement.Client;
@@ -53,7 +54,17 @@ namespace Microsoft.Health.Fhir.TemplateManagement.UnitTests
         }
 
         [Fact]
-        public async System.Threading.Tasks.Task GivenARequestFromACRClient_WhenPullBlob_IfHttpRequestErrorOnceAndRetrySucceed_BlobStreamWillBeReturnAsync()
+        public void GivenARequestFromACRClient_WhenPullBlob_IfHttpRequestError_ExceptionWillBeThrown()
+        {
+            var acrClientMock = new Mock<IAzureContainerRegistryClient>();
+            acrClientMock.Setup(p => p.Blob).Throws(new HttpRequestException());
+            var client = new ACRClient(acrClientMock.Object);
+            Assert.ThrowsAsync<ImageFetchException>(() => client.PullBlobAsBytesAcync(_imageName, _digest));
+            Assert.ThrowsAsync<ImageFetchException>(() => client.PullBlobAsStreamAcync(_imageName, _digest));
+        }
+
+        [Fact]
+        public async Task GivenARequestFromACRClient_WhenPullBlob_IfHttpRequestErrorOnceAndRetrySucceed_BlobStreamWillBeReturnAsync()
         {
             var acrClientMock = new Mock<IAzureContainerRegistryClient>();
             acrClientMock.Setup(p => p.Blob).Throws(new HttpRequestException());

--- a/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/Client/ACRClientTests.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/Client/ACRClientTests.cs
@@ -53,6 +53,16 @@ namespace Microsoft.Health.Fhir.TemplateManagement.UnitTests
         }
 
         [Fact]
+        public void GivenARequestFromACRClient_WhenPullBlob_IfHttpRequestError_ImageFetchExceptionWillBeThrown()
+        {
+            var acrClientMock = new Mock<IAzureContainerRegistryClient>();
+            acrClientMock.Setup(p => p.Blob).Throws(new HttpRequestException());
+            var client = new ACRClient(acrClientMock.Object);
+            Assert.ThrowsAsync<ImageFetchException>(() => client.PullBlobAsBytesAcync(_imageName, _digest));
+            Assert.ThrowsAsync<ImageFetchException>(() => client.PullBlobAsStreamAcync(_imageName, _digest));
+        }
+
+        [Fact]
         public void GivenARequestFromACRClient_WhenPullBlob_IfNotFound_ImageNotFoundExceptionWillBeThrown()
         {
             var acrClientMock = new Mock<IAzureContainerRegistryClient>();

--- a/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/Client/ACRClientTests.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/Client/ACRClientTests.cs
@@ -53,13 +53,13 @@ namespace Microsoft.Health.Fhir.TemplateManagement.UnitTests
         }
 
         [Fact]
-        public void GivenARequestFromACRClient_WhenPullBlob_IfHttpRequestError_ImageFetchExceptionWillBeThrown()
+        public async System.Threading.Tasks.Task GivenARequestFromACRClient_WhenPullBlob_IfHttpRequestErrorOnceAndRetrySucceed_BlobStreamWillBeReturnAsync()
         {
             var acrClientMock = new Mock<IAzureContainerRegistryClient>();
             acrClientMock.Setup(p => p.Blob).Throws(new HttpRequestException());
-            var client = new ACRClient(acrClientMock.Object);
-            Assert.ThrowsAsync<ImageFetchException>(() => client.PullBlobAsBytesAcync(_imageName, _digest));
-            Assert.ThrowsAsync<ImageFetchException>(() => client.PullBlobAsStreamAcync(_imageName, _digest));
+            var client = new ACRClient(new MockACRClient());
+            var result = await client.PullBlobAsStreamAcync(_imageName, _digest);
+            Assert.NotNull(result);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/MockACRClient.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/MockACRClient.cs
@@ -4,16 +4,8 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net.Http;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Azure.ContainerRegistry;
-using Microsoft.Azure.ContainerRegistry.Models;
 using Microsoft.Rest;
-using Microsoft.Rest.Azure;
 using Newtonsoft.Json;
 
 namespace Microsoft.Health.Fhir.TemplateManagement.UnitTests

--- a/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/MockACRClient.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/MockACRClient.cs
@@ -1,0 +1,56 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.ContainerRegistry;
+using Microsoft.Azure.ContainerRegistry.Models;
+using Microsoft.Rest;
+using Microsoft.Rest.Azure;
+using Newtonsoft.Json;
+
+namespace Microsoft.Health.Fhir.TemplateManagement.UnitTests
+{
+    public class MockACRClient : IAzureContainerRegistryClient
+    {
+        public JsonSerializerSettings SerializationSettings => throw new NotImplementedException();
+
+        public JsonSerializerSettings DeserializationSettings => throw new NotImplementedException();
+
+        public ServiceClientCredentials Credentials => throw new NotImplementedException();
+
+        public string LoginUri { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public string AcceptLanguage { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public int? LongRunningOperationRetryTimeout { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public bool? GenerateClientRequestId { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public IV2SupportOperations V2Support => throw new NotImplementedException();
+
+        public IManifestsOperations Manifests => throw new NotImplementedException();
+
+        public IRepositoryOperations Repository => throw new NotImplementedException();
+
+        public ITagOperations Tag => throw new NotImplementedException();
+
+        public IRefreshTokensOperations RefreshTokens => throw new NotImplementedException();
+
+        public IAccessTokensOperations AccessTokens => throw new NotImplementedException();
+
+        IBlobOperations IAzureContainerRegistryClient.Blob { get; } = new MockBlobOperations();
+
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/MockBlobOperations.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/MockBlobOperations.cs
@@ -1,0 +1,85 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.ContainerRegistry;
+using Microsoft.Azure.ContainerRegistry.Models;
+using Microsoft.Rest.Azure;
+
+namespace Microsoft.Health.Fhir.TemplateManagement.UnitTests
+{
+    public class MockBlobOperations : IBlobOperations
+    {
+        private int _index = 0;
+
+        public Task<AzureOperationResponse> CancelUploadWithHttpMessagesAsync(string location, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<AzureOperationHeaderResponse<BlobCheckChunkHeaders>> CheckChunkWithHttpMessagesAsync(string name, string digest, string range, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<AzureOperationHeaderResponse<BlobCheckHeaders>> CheckWithHttpMessagesAsync(string name, string digest, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<AzureOperationResponse<Stream, BlobDeleteHeaders>> DeleteWithHttpMessagesAsync(string name, string digest, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<AzureOperationHeaderResponse<BlobEndUploadHeaders>> EndUploadWithHttpMessagesAsync(string digest, string location, Stream value = null, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<AzureOperationResponse<Stream, BlobGetChunkHeaders>> GetChunkWithHttpMessagesAsync(string name, string digest, string range, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<AzureOperationHeaderResponse<BlobGetStatusHeaders>> GetStatusWithHttpMessagesAsync(string location, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<AzureOperationResponse<Stream, BlobGetHeaders>> GetWithHttpMessagesAsync(string name, string digest, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default)
+        {
+            if (_index == 0)
+            {
+                _index += 1;
+                throw new HttpRequestException();
+            }
+            else
+            {
+                return Task.FromResult(result: new AzureOperationResponse<Stream, BlobGetHeaders>() { Body = new MemoryStream(), Request = new HttpRequestMessage() });
+            }
+        }
+
+        public Task<AzureOperationHeaderResponse<BlobMountHeaders>> MountWithHttpMessagesAsync(string name, string fromParameter, string mount, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<AzureOperationHeaderResponse<BlobStartUploadHeaders>> StartUploadWithHttpMessagesAsync(string name, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<AzureOperationHeaderResponse<BlobUploadHeaders>> UploadWithHttpMessagesAsync(Stream value, string location, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.TemplateManagement/Client/ACRClient.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Client/ACRClient.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Health.Fhir.TemplateManagement.Client
             try
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                rawStream = await _retryPolicy.ExecuteAsync(async () => await _client.Blob.GetAsync(imageName, digest, cancellationToken));
+                rawStream = await _retryPolicy.ExecuteAsync(async (cancellationToken) => await _client.Blob.GetAsync(imageName, digest, cancellationToken), cancellationToken);
                 return rawStream;
             }
             catch (TemplateManagementException)

--- a/src/Microsoft.Health.Fhir.TemplateManagement/Client/ACRClient.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Client/ACRClient.cs
@@ -19,7 +19,6 @@ using Microsoft.Health.Fhir.TemplateManagement.Utilities;
 using Microsoft.Rest;
 using Microsoft.Rest.Azure;
 using Polly;
-using Polly.Retry;
 
 namespace Microsoft.Health.Fhir.TemplateManagement.Client
 {
@@ -52,7 +51,7 @@ namespace Microsoft.Health.Fhir.TemplateManagement.Client
             try
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                rawStream = await _retryPolicy.ExecuteAsync(async() => await _client.Blob.GetAsync(imageName, digest, cancellationToken));
+                rawStream = await _retryPolicy.ExecuteAsync(async () => await _client.Blob.GetAsync(imageName, digest, cancellationToken));
                 return rawStream;
             }
             catch (TemplateManagementException)

--- a/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.TemplateManagement.csproj
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.TemplateManagement.csproj
@@ -32,7 +32,7 @@
       <Link>Hl7v2DefaultTemplates.tar.gz</Link>
     </EmbeddedResource>
   </ItemGroup>
-  
+
   <ItemGroup>
     <None Update="oras.exe">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.TemplateManagement.csproj
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.TemplateManagement.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="RestSharp" Version="106.11.5" />
     <PackageReference Include="SharpCompress" Version="0.26.0" />
     <PackageReference Include="SharpZipLib" Version="1.3.0" />

--- a/src/Microsoft.Health.Fhir.TemplateManagement/TemplateManagementLogging.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/TemplateManagementLogging.cs
@@ -1,0 +1,16 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Health.Fhir.TemplateManagement
+{
+    public static class TemplateManagementLogging
+    {
+        public static ILoggerFactory LoggerFactory { get; set; } = new LoggerFactory();
+
+        public static ILogger CreateLogger<T>() => LoggerFactory.CreateLogger<T>();
+    }
+}


### PR DESCRIPTION
Retry one time when catch HttpRequestException only for fhir server. (No retry for vscode)