### PR TITLE
Make build cross-platform with respect to Oras

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -360,3 +360,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# JetBrains tooling
+.idea/

--- a/docs/TemplateManagementCLI.md
+++ b/docs/TemplateManagementCLI.md
@@ -36,11 +36,18 @@ To use docker login, you should install docker first. Docker provides packages t
 ```
 * Oras Login
 
-The [oras](https://github.com/deislabs/oras) tool oras.exe for windows is packed in our repo, users can directly use it for login as follows.
+The [oras](https://github.com/deislabs/oras) tool is downloaded during a build. Users can directly use it for login as follows
 
+Windows:
 ```
 >.\oras.exe login <acrName.azurecr.io> -u <username> -p <password>
 ```
+
+Linux or macOS:
+```
+$ ./oras login <acrName.azurecr.io> -u <username> -p <password>
+```
+
 
 If using service principal's identity for authentication, you need to create a [service principal](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-auth-service-principal) to access your registry. Ensure that the service principal is assigned a role such as AcrPush so that it has permissions to push and pull artifacts.
 ## Push

--- a/release.yml
+++ b/release.yml
@@ -20,6 +20,7 @@ variables:
   bulidnum: $[counter(format('{0}.{1}',variables['major'],variables['minor']), 100)]
   revision: $[counter(format('{0:yyyyMMdd}', pipeline.startTime), 1)]
   version: $(major).$(minor).$(bulidnum).$(revision)
+  orasVersion: 0.8.1
 
 stages:
 - stage: Build
@@ -171,11 +172,11 @@ stages:
         artifactName: FhirConverterBuild
         downloadPath: $(System.DefaultWorkingDirectory)
     - script: |
-        curl -LO https://github.com/deislabs/oras/releases/download/v0.8.1/oras_0.8.1_linux_amd64.tar.gz
+        curl -LO https://github.com/deislabs/oras/releases/download/v$(orasVersion)/oras_$(orasVersion)_linux_amd64.tar.gz
         mkdir -p oras-install/
-        tar -zxf oras_0.8.1_*.tar.gz -C oras-install/
+        tar -zxf oras_$(orasVersion)_*.tar.gz -C oras-install/
         mv oras-install/oras /usr/local/bin/
-        rm -rf oras_0.8.1_*.tar.gz oras-install/
+        rm -rf oras_$(orasVersion)_*.tar.gz oras-install/
         docker run --rm -d -p 5000:5000 --name registry registry:2
       displayName: start registry
     - script: |

--- a/src/Microsoft.Health.Fhir.TemplateManagement/.gitignore
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/.gitignore
@@ -1,0 +1,3 @@
+# Preserve existing expectation that the build will place the oras binary here, but let's keep it out of Git.
+/oras
+/oras.exe

--- a/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.TemplateManagement.csproj
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.TemplateManagement.csproj
@@ -5,7 +5,10 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>true</IsPackable>
     <NuspecFile>Microsoft.Health.Fhir.Liquid.Converter.nuspec</NuspecFile>
-    <OrasWinUrl>https://github.com/deislabs/oras/releases/download/v0.8.1/oras_0.8.1_windows_amd64.tar.gz</OrasWinUrl>
+    <OrasVersion>0.8.1</OrasVersion>
+    <OsEnvironment Condition="'$(OS)' == 'Windows_NT'">windows</OsEnvironment>
+    <OsEnvironment Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))'">darwin</OsEnvironment>
+    <OsEnvironment Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'">linux</OsEnvironment>
   </PropertyGroup>
   
   <ItemGroup>
@@ -31,21 +34,23 @@
       <Link>Hl7v2DefaultTemplates.tar.gz</Link>
     </EmbeddedResource>
   </ItemGroup>
-  
+
   <ItemGroup>
-    <None Update="oras.exe">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <None Condition="'$(OsEnvironment)' == 'windows'" Include="oras.exe" CopyToOutputDirectory="PreserveNewest" />
+    <None Condition="'$(OsEnvironment)' != 'windows'" Include="oras" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="mkdir ..\..\bin &amp; tar -zcvf ../../bin/Hl7v2DefaultTemplates.tar.gz -C ../../data/Templates/Hl7v2 ." />
+    <Exec Condition="'$(OsEnvironment)' == 'windows'" Command="mkdir ../../bin &amp; tar -zcvf ../../bin/Hl7v2DefaultTemplates.tar.gz -C ../../data/Templates/Hl7v2 ." />
+    <Exec Condition="'$(OsEnvironment)' != 'windows'" Command="mkdir ../../bin ; tar -zcvf ../../bin/Hl7v2DefaultTemplates.tar.gz -C ../../data/Templates/Hl7v2 ." />
   </Target>
-  
-  <Target Name="DownloadOrasFile" BeforeTargets="Build">
-    <DownloadFile SourceUrl="$(OrasWinUrl)" DestinationFolder="../../bin">
+
+  <Target Name="DownloadOrasFile" BeforeTargets="PreBuildEvent">
+    <DownloadFile SourceUrl="https://github.com/deislabs/oras/releases/download/v$(OrasVersion)/oras_$(OrasVersion)_$(OsEnvironment)_amd64.tar.gz" DestinationFolder="../../bin">
       <Output TaskParameter="DownloadedFile" ItemName="Content" />
     </DownloadFile>
-    <Exec Command="tar -xvf ..\..\bin\oras_0.8.1_windows_amd64.tar.gz -C ..\..\bin &amp; copy ..\..\bin\oras.exe ." />
+    <Exec Condition="'$(OsEnvironment)' == 'windows'" Command="tar -xzvf ..\..\bin\oras_$(OrasVersion)_windows_amd64.tar.gz -C ..\..\bin &amp; copy ..\..\bin\oras.exe ." />
+    <Exec Condition="'$(OsEnvironment)' != 'windows'" Command="tar -xzvf ../../bin/oras_$(OrasVersion)_$(OsEnvironment)_amd64.tar.gz -C ../../bin ; cp ../../bin/oras ." />
   </Target>
+  
 </Project>


### PR DESCRIPTION
This PR takes into account the difference between Windows, Linux, and macOS when it comes to the Oras binary. This makes local development of this project "just work" for non-Windows developers.

As part of the minor refactor, it also makes changing the version of the binary easier by referencing variables. This PR does not change the version and it is preserved at `v0.8.1`. Additionally, a couple more things were added to the `.gitignore` context to help keep the repo clean.

This is my first PR; feel free to rip it apart; I'm not  really a .NET developer (yet?) and take no offense. I'm working on the Microsoft CLA right now; instructions say to wait for the bot to comment.