### PR TITLE
Move reference ID evaluation statements inside resource tempaltes to simplify usage

### DIFF
--- a/data/Templates/Hl7v2/ADT_A01.liquid
+++ b/data/Templates/Hl7v2/ADT_A01.liquid
@@ -113,7 +113,7 @@
             {% include 'Resource/Practitioner' DG1: dg1Segment, ID: practitionerId_DG1_16 -%}
 
             {% evaluate conditionId using 'ID/Condition' DG1: dg1Segment, baseId: patientId -%}
-            {% include 'Resource/Condition' DG1: dg1Segment, Condition_Subject_ID: fullPatientId, Practitioner_ID_DG1_16: practitionerId_DG1_16, ID: conditionId -%}
+            {% include 'Resource/Condition' DG1: dg1Segment, Condition_Subject_ID: fullPatientId, ID: conditionId -%}
 
             {% assign fullConditionId = conditionId | prepend: 'Condition/' -%}
             {% include 'Reference/Encounter/Diagnosis_Condition' ID: encounterId, REF: fullConditionId -%}

--- a/data/Templates/Hl7v2/ADT_A01.liquid
+++ b/data/Templates/Hl7v2/ADT_A01.liquid
@@ -57,7 +57,7 @@
         {% include 'Resource/Provenance' Root_Template: 'ADT_A01', MSH: firstSegments.MSH, ORC: firstSegments.ORC, ID: provenanceId -%}
 
         {% evaluate encounterId using 'ID/Encounter' PV1: firstSegments.PV1, baseId: patientId -%}
-        {% include 'Resource/Encounter' PV1: firstSegments.PV1, PV2: firstSegments.PV2, Location_ID_PV1_3: locationId_PV1_3, Location_ID_PV1_6: locationId_PV1_6, Practitioner_ID_PV1_7: practitionerId_PV1_7, Practitioner_ID_PV1_8: practitionerId_PV1_8, Practitioner_ID_PV1_9: practitionerId_PV1_9, Practitioner_ID_PV1_17: practitionerId_PV1_17, Practitioner_ID_PV1_52: practitionerId_PV1_52, ID: encounterId -%}
+        {% include 'Resource/Encounter' PV1: firstSegments.PV1, PV2: firstSegments.PV2, ID: encounterId -%}
         {% include 'Reference/Encounter/Subject' ID: encounterId, REF: fullPatientId -%}
 
         {% for pr1Segment in pr1SegmentLists.PR1 -%}

--- a/data/Templates/Hl7v2/ADT_A01.liquid
+++ b/data/Templates/Hl7v2/ADT_A01.liquid
@@ -72,7 +72,7 @@
             {% evaluate organizationId_NK1_13 using 'ID/Organization' XON: nk1Segment.13 -%}
             {% include 'Resource/Organization' NK1: nk1Segment, ID: organizationId_NK1_13 -%}
 
-            {% include 'Resource/Patient' NK1: nk1Segment, Organization_ID_NK1_13: organizationId_NK1_13, ID: patientId -%}
+            {% include 'Resource/Patient' NK1: nk1Segment, ID: patientId -%}
 
             {% evaluate relatedPersonId using 'ID/RelatedPerson' NK1: nk1Segment, baseId: patientId -%}
             {% include 'Resource/RelatedPerson' NK1: nk1Segment, RelatedPerson_Patient_ID: fullPatientId, ID: relatedPersonId -%}

--- a/data/Templates/Hl7v2/ADT_A01.liquid
+++ b/data/Templates/Hl7v2/ADT_A01.liquid
@@ -91,7 +91,7 @@
 
             {% evaluate practitionerRoleId_OBX_25 using 'ID/PractitionerRole' XCN: obxSegment.25 -%}
             {% if obxSegment.16 or obxSegment.23 or obxSegment.25 -%}
-                {% include 'Resource/PractitionerRole' OBX: obxSegment, Practitioner_ID_OBX_16: practitionerId_OBX_16, Organization_ID_OBX_23: organizationId_OBX_23, ID: practitionerRoleId_OBX_25 -%}
+                {% include 'Resource/PractitionerRole' OBX: obxSegment, ID: practitionerRoleId_OBX_25 -%}
             {% endif -%}
 
             {% evaluate deviceId_OBX_18 using 'ID/Device' HD: obxSegment.18 -%}

--- a/data/Templates/Hl7v2/ADT_A01.liquid
+++ b/data/Templates/Hl7v2/ADT_A01.liquid
@@ -54,7 +54,7 @@
         {% include 'Resource/Location' PL: firstSegments.PV1.6, ID: locationId_PV1_6 -%}
 
         {% evaluate provenanceId using 'ID/Provenance' MSH: firstSegments.MSH, baseId: patientId -%}
-        {% include 'Resource/Provenance' Root_Template: 'ADT_A01', MSH: firstSegments.MSH, ORC: firstSegments.ORC, Practitioner_ID_ORC_10: practitionerId_ORC_10, Practitioner_ID_ORC_11: practitionerId_ORC_11, Practitioner_ID_ORC_12: practitionerId_ORC_12, Location_ID_ORC_21: locationId_ORC_21, ID: provenanceId -%}
+        {% include 'Resource/Provenance' Root_Template: 'ADT_A01', MSH: firstSegments.MSH, ORC: firstSegments.ORC, ID: provenanceId -%}
 
         {% evaluate encounterId using 'ID/Encounter' PV1: firstSegments.PV1, baseId: patientId -%}
         {% include 'Resource/Encounter' PV1: firstSegments.PV1, PV2: firstSegments.PV2, Location_ID_PV1_3: locationId_PV1_3, Location_ID_PV1_6: locationId_PV1_6, Practitioner_ID_PV1_7: practitionerId_PV1_7, Practitioner_ID_PV1_8: practitionerId_PV1_8, Practitioner_ID_PV1_9: practitionerId_PV1_9, Practitioner_ID_PV1_17: practitionerId_PV1_17, Practitioner_ID_PV1_52: practitionerId_PV1_52, ID: encounterId -%}

--- a/data/Templates/Hl7v2/ADT_A01.liquid
+++ b/data/Templates/Hl7v2/ADT_A01.liquid
@@ -100,7 +100,7 @@
             {% endif -%}
 
             {% evaluate observationId using 'ID/Observation' OBX: obxSegment, baseId: patientId -%}
-            {% include 'Resource/Observation' OBX: obxSegment, Observation_Subject_ID: fullPatientId, Practitioner_ID_OBX_16: practitionerId_OBX_16, PractitionerRole_ID_OBX_25: practitionerRoleId_OBX_25, Organization_ID_OBX_23: organizationId_OBX_23, ID: observationId -%}
+            {% include 'Resource/Observation' OBX: obxSegment, Observation_Subject_ID: fullPatientId, ID: observationId -%}
         {% endfor -%}
 
         {% for al1Segment in al1SegmentLists.AL1 -%}

--- a/data/Templates/Hl7v2/OML_O21.liquid
+++ b/data/Templates/Hl7v2/OML_O21.liquid
@@ -118,7 +118,7 @@
 
                 {% evaluate practitionerRoleId_OBX_25 using 'ID/PractitionerRole' XCN: obxSegment.25 -%}
                 {% if obxSegment.16 or obxSegment.23 or obxSegment.25 -%}
-                    {% include 'Resource/PractitionerRole' OBX: obxSegment, Practitioner_ID_OBX_16: practitionerId_OBX_16, Organization_ID_OBX_23: organizationId_OBX_23, ID: practitionerRoleId_OBX_25 -%}
+                    {% include 'Resource/PractitionerRole' OBX: obxSegment, ID: practitionerRoleId_OBX_25 -%}
                 {% endif -%}
 
                 {% evaluate deviceId_OBX_18 using 'ID/Device' HD: obxSegment.18 -%}

--- a/data/Templates/Hl7v2/OML_O21.liquid
+++ b/data/Templates/Hl7v2/OML_O21.liquid
@@ -68,7 +68,7 @@
             {% evaluate organizationId_NK1_13 using 'ID/Organization' XON: nk1Segment.13 -%}
             {% include 'Resource/Organization' NK1: nk1Segment, ID: organizationId_NK1_13 -%}
 
-            {% include 'Resource/Patient' NK1: nk1Segment, Organization_ID_NK1_13: organizationId_NK1_13, ID: patientId -%}
+            {% include 'Resource/Patient' NK1: nk1Segment, ID: patientId -%}
 
             {% evaluate relatedPersonId using 'ID/RelatedPerson' NK1: nk1Segment, baseId: patientId -%}
             {% include 'Resource/RelatedPerson' NK1: nk1Segment, RelatedPerson_Patient_ID: fullPatientId, ID: relatedPersonId -%}

--- a/data/Templates/Hl7v2/OML_O21.liquid
+++ b/data/Templates/Hl7v2/OML_O21.liquid
@@ -127,7 +127,7 @@
                 {% endif -%}
 
                 {% evaluate observationId using 'ID/Observation' OBX: obxSegment, baseId: patientId -%}
-                {% include 'Resource/Observation' OBX: obxSegment, Observation_Subject_ID: fullPatientId, Practitioner_ID_OBX_16: practitionerId_OBX_16, PractitionerRole_ID_OBX_25: practitionerRoleId_OBX_25, Organization_ID_OBX_23: organizationId_OBX_23, ID: observationId -%}
+                {% include 'Resource/Observation' OBX: obxSegment, Observation_Subject_ID: fullPatientId, ID: observationId -%}
 
                 {% assign fullObservationId = observationId | prepend: 'Observation/' -%}
                 {% include 'Reference/ServiceRequest/SupportingInfo' ID: serviceRequestId, REF: fullObservationId -%}

--- a/data/Templates/Hl7v2/OML_O21.liquid
+++ b/data/Templates/Hl7v2/OML_O21.liquid
@@ -49,7 +49,7 @@
         {% include 'Resource/Location' PL: firstSegments.PV1.6, ID: locationId3_PV1_6 -%}
 
         {% evaluate provenanceId using 'ID/Provenance' MSH: firstSegments.MSH, baseId: patientId -%}
-        {% include 'Resource/Provenance' Root_Template: 'OML_O21', MSH: firstSegments.MSH, ORC: firstSegments.ORC, Practitioner_ID_ORC_10: practitionerId10_ORC_10, Practitioner_ID_ORC_11: practitionerId10_ORC_11, Practitioner_ID_ORC_12: practitionerId10_ORC_12, Location_ID_ORC_21: locationId_ORC_21, ID: provenanceId -%}
+        {% include 'Resource/Provenance' Root_Template: 'OML_O21', MSH: firstSegments.MSH, ORC: firstSegments.ORC, ID: provenanceId -%}
 
         {% evaluate accountId using 'ID/Account' CX: firstSegments.PID.3 -%}
         {% include 'Resource/Account' PID: firstSegments.PID, ID: accountId -%}
@@ -91,7 +91,7 @@
             {% include 'Resource/ServiceRequest' ORC: orcSegment, ServiceRequest_Subject_ID: fullPatientId, Organization_ID_ORC_21: organizationId_ORC_21, ID: serviceRequestId -%}
 
             {% evaluate provenanceId using 'ID/Provenance' ORC: orcSegment, baseId: patientId -%}
-            {% include 'Resource/Provenance' ORC: orcSegment, Organization_ID_ORC_17: organizationId_ORC_17, ID: provenanceId -%}
+            {% include 'Resource/Provenance' ORC: orcSegment, ID: provenanceId -%}
             {% include 'Reference/Provenance/Target' ID: provenanceId, REF: fullServiceRequestId -%}
 
             {% for tq1Segment in tq1SegmentLists.TQ1 -%}

--- a/data/Templates/Hl7v2/OML_O21.liquid
+++ b/data/Templates/Hl7v2/OML_O21.liquid
@@ -56,7 +56,7 @@
         {% include 'Reference/Account/Subject' ID: accountId, REF: fullPatientId -%}
 
         {% evaluate encounterId using 'ID/Encounter' PV1: firstSegments.PV1, baseId: patientId -%}
-        {% include 'Resource/Encounter' PV1: firstSegments.PV1, PV2: firstSegments.PV2, Location_ID_PV1_3: locationId3_PV1_3, Location_ID_PV1_6: locationId3_PV1_6, Practitioner_ID_PV1_7: practitionerId7_PV1_7, Practitioner_ID_PV1_8: practitionerId7_PV1_8, Practitioner_ID_PV1_9: practitionerId7_PV1_9, Practitioner_ID_PV1_17: practitionerId7_PV1_17, Practitioner_ID_PV1_52: practitionerId7_PV1_52, ID: encounterId -%}
+        {% include 'Resource/Encounter' PV1: firstSegments.PV1, PV2: firstSegments.PV2, ID: encounterId -%}
         {% include 'Reference/Encounter/Subject' ID: encounterId, REF: fullPatientId -%}
 
         {% for al1Segment in al1SegmentLists.AL1 -%}

--- a/data/Templates/Hl7v2/OML_O21.liquid
+++ b/data/Templates/Hl7v2/OML_O21.liquid
@@ -88,7 +88,7 @@
 
             {% evaluate serviceRequestId using 'ID/ServiceRequest' ORC: orcSegment, baseId: patientId -%}
             {% assign fullServiceRequestId = serviceRequestId | prepend: 'ServiceRequest/' -%}
-            {% include 'Resource/ServiceRequest' ORC: orcSegment, ServiceRequest_Subject_ID: fullPatientId, Organization_ID_ORC_21: organizationId_ORC_21, ID: serviceRequestId -%}
+            {% include 'Resource/ServiceRequest' ORC: orcSegment, ServiceRequest_Subject_ID: fullPatientId, ID: serviceRequestId -%}
 
             {% evaluate provenanceId using 'ID/Provenance' ORC: orcSegment, baseId: patientId -%}
             {% include 'Resource/Provenance' ORC: orcSegment, ID: provenanceId -%}
@@ -102,7 +102,7 @@
                 {% evaluate practitionerId_OBR_10 using 'ID/Practitioner' XCN: obrSegment.10 -%}
                 {% include 'Resource/Practitioner' OBR: obrSegment, ID: practitionerId_OBR_10 -%}
 
-                {% include 'Resource/ServiceRequest' OBR: obrSegment, Practitioner_ID_OBR_10: practitionerId_OBR_10, ID: serviceRequestId -%}
+                {% include 'Resource/ServiceRequest' OBR: obrSegment, ID: serviceRequestId -%}
             {% endfor -%}
 
             {% for obxSegment in obxSegmentLists.OBX -%}

--- a/data/Templates/Hl7v2/OML_O21.liquid
+++ b/data/Templates/Hl7v2/OML_O21.liquid
@@ -138,7 +138,7 @@
                 {% include 'Resource/Practitioner' DG1: dg1Segment, ID: practitionerId_DG1_16 -%}
 
                 {% evaluate conditionId using 'ID/Condition' DG1: dg1Segment, baseId: patientId -%}
-                {% include 'Resource/Condition' DG1: obxSegment, Condition_Subject_ID: fullPatientId, Practitioner_ID_DG1_16: practitionerId_DG1_16, ID: conditionId -%}
+                {% include 'Resource/Condition' DG1: obxSegment, Condition_Subject_ID: fullPatientId, ID: conditionId -%}
 
                 {% assign fullConditionId = conditionId | prepend: 'Condition/' -%}
                 {% include 'Reference/ServiceRequest/ReasonReference' ID: serviceRequestId, REF: fullConditionId -%}

--- a/data/Templates/Hl7v2/ORU_R01.liquid
+++ b/data/Templates/Hl7v2/ORU_R01.liquid
@@ -47,7 +47,7 @@
         {% include 'Resource/Location' ORC: firstSegments.ORC, ID: locationId_ORC_21 -%}
 
         {% evaluate provenanceId using 'ID/Provenance' MSH: firstSegments.MSH, baseId: patientId -%}
-        {% include 'Resource/Provenance' Root_Template: 'ORU_R01', MSH: firstSegments.MSH, ORC: firstSegments.ORC, Practitioner_ID_ORC_10: practitionerId10_ORC_10, Practitioner_ID_ORC_11: practitionerId10_ORC_11, Practitioner_ID_ORC_12: practitionerId10_ORC_12, Location_ID_ORC_21: locationId_ORC_21, ID: provenanceId -%}
+        {% include 'Resource/Provenance' Root_Template: 'ORU_R01', MSH: firstSegments.MSH, ORC: firstSegments.ORC, ID: provenanceId -%}
 
         {% evaluate accountId using 'ID/Account' CX: firstSegments.PID.3 -%}
         {% include 'Resource/Account' PID: firstSegments.PID, ID: accountId -%}

--- a/data/Templates/Hl7v2/ORU_R01.liquid
+++ b/data/Templates/Hl7v2/ORU_R01.liquid
@@ -62,7 +62,7 @@
             {% evaluate organizationId_NK1_13 using 'ID/Organization' XON: nk1Segment.13 -%}
             {% include 'Resource/Organization' NK1: nk1Segment, ID: organizationId_NK1_13 -%}
 
-            {% include 'Resource/Patient' NK1: nk1Segment, Organization_ID_NK1_13: organizationId_NK1_13, ID: patientId -%}
+            {% include 'Resource/Patient' NK1: nk1Segment, ID: patientId -%}
 
             {% evaluate relatedPersonId using 'ID/RelatedPerson' NK1: nk1Segment, baseId: patientId -%}
             {% include 'Resource/RelatedPerson' NK1: nk1Segment, RelatedPerson_Patient_ID: fullPatientId, ID: relatedPersonId -%}

--- a/data/Templates/Hl7v2/ORU_R01.liquid
+++ b/data/Templates/Hl7v2/ORU_R01.liquid
@@ -55,7 +55,7 @@
 
         {% evaluate encounterId using 'ID/Encounter' PV1: firstSegments.PV1, baseId: patientId -%}
         {% assign fullEncounterId = encounterId | prepend: 'Encounter/' -%}
-        {% include 'Resource/Encounter' PV1: firstSegments.PV1, PV2: firstSegments.PV2, Location_ID_PV1_3: locationId_PV1_3, Location_ID_PV1_6: locationId_PV1_6, Practitioner_ID_PV1_7: practitionerId_PV1_7, Practitioner_ID_PV1_8: practitionerId_PV1_8, Practitioner_ID_PV1_9: practitionerId_PV1_9, Practitioner_ID_PV1_17: practitionerId_PV1_17, Practitioner_ID_PV1_52: practitionerId_PV1_52, ID: encounterId -%}
+        {% include 'Resource/Encounter' PV1: firstSegments.PV1, PV2: firstSegments.PV2, ID: encounterId -%}
         {% include 'Reference/Encounter/Subject' ID: encounterId, REF: fullPatientId -%}
 
         {% for nk1Segment in nk1SegmentLists.NK1 -%}

--- a/data/Templates/Hl7v2/ORU_R01.liquid
+++ b/data/Templates/Hl7v2/ORU_R01.liquid
@@ -91,7 +91,7 @@
 
                 {% evaluate practitionerRoleId_OBX_25 using 'ID/PractitionerRole' XCN: obxSegment.25 -%}
                 {% if obxSegment.16 or obxSegment.23 or obxSegment.25 -%}
-                    {% include 'Resource/PractitionerRole' OBX: obxSegment, Practitioner_ID_OBX_16: practitionerId_OBX_16, Organization_ID_OBX_23: organizationId_OBX_23, ID: practitionerRoleId_OBX_25 -%}
+                    {% include 'Resource/PractitionerRole' OBX: obxSegment, ID: practitionerRoleId_OBX_25 -%}
                 {% endif -%}
 
                 {% evaluate deviceId_OBX_18 using 'ID/Device' HD: obxSegment.18 -%}

--- a/data/Templates/Hl7v2/ORU_R01.liquid
+++ b/data/Templates/Hl7v2/ORU_R01.liquid
@@ -100,7 +100,7 @@
                 {% endif -%}
 
                 {% evaluate observationId using 'ID/Observation' OBX: obxSegment, baseId: patientId -%}
-                {% include 'Resource/Observation' OBX: obxSegment, Observation_Subject_ID: fullPatientId, Practitioner_ID_OBX_16: practitionerId_OBX_16, PractitionerRole_ID_OBX_25: practitionerRoleId_OBX_25, Organization_ID_OBX_23: organizationId_OBX_23, ID: observationId -%}
+                {% include 'Resource/Observation' OBX: obxSegment, Observation_Subject_ID: fullPatientId, ID: observationId -%}
 
                 {% assign fullObservationId = observationId | prepend: 'Observation/' -%}
                 {% include 'Reference/DiagnosticReport/Result' ID: diagnosticId, REF: fullObservationId -%}

--- a/data/Templates/Hl7v2/ORU_R01.liquid
+++ b/data/Templates/Hl7v2/ORU_R01.liquid
@@ -76,7 +76,7 @@
             {% include 'Resource/Practitioner' OBR: obrSegment, ID: practitionerId_OBR_10 -%}
 
             {% evaluate diagnosticId using 'ID/DiagnosticReport' OBR: obrSegment, baseId: patientId -%}
-            {% include 'Resource/DiagnosticReport' OBR: obrSegment, DiagnosticReport_Encounter_ID: fullEncounterId, Practitioner_ID_OBR_10: practitionerId_OBR_10, ID: diagnosticId -%}
+            {% include 'Resource/DiagnosticReport' OBR: obrSegment, DiagnosticReport_Encounter_ID: fullEncounterId, ID: diagnosticId -%}
 
             {% for obxSegment in obxSegmentLists.OBX -%}
                 {% evaluate organizationId_OBX_23 using 'ID/Organization' XON: obxSegment.23 -%}

--- a/data/Templates/Hl7v2/Resource/_Condition.liquid
+++ b/data/Templates/Hl7v2/Resource/_Condition.liquid
@@ -7,6 +7,8 @@ Condition_Encounter_ID: A resource Id, used to fill "encounter.reference" proper
 Condition_Recorder_ID: A resource Id, used to fill "recorder.reference" property.
 {% endcomment -%}
 
+{% evaluate Practitioner_ID_DG1_16 using 'ID/Practitioner' XCN: DG1.16 -%}
+
 {
     "fullUrl":"urn:uuid:{{ ID }}",
     "resource":{

--- a/data/Templates/Hl7v2/Resource/_DiagnosticReport.liquid
+++ b/data/Templates/Hl7v2/Resource/_DiagnosticReport.liquid
@@ -9,6 +9,8 @@ DiagnosticReport_Subject_ID: A resource Id, used to fill "subject.reference" pro
 DiagnosticReport_Encounter_ID: A resource Id, used to fill "encounter.reference" property.
 {% endcomment -%}
 
+{% evaluate Practitioner_ID_OBR_10 using 'ID/Practitioner' XCN: OBR.10 -%}
+
 {
     "fullUrl":"urn:uuid:{{ ID }}",
     "resource":{

--- a/data/Templates/Hl7v2/Resource/_Encounter.liquid
+++ b/data/Templates/Hl7v2/Resource/_Encounter.liquid
@@ -12,6 +12,14 @@ Practitioner_ID_PV1_17: A resource Id, used to fill "participant.individual.refe
 Practitioner_ID_PV1_52: A resource Id, used to fill "participant.individual.reference" property. The resource is of "Practitioner" type and generated based on "PV1.52" HL7 V2 identifier.
 {% endcomment -%}
 
+{% evaluate Location_ID_PV1_3 using 'ID/Location' PL: PV1.3 -%}
+{% evaluate Location_ID_PV1_6 using 'ID/Location' PL: PV1.6 -%}
+{% evaluate Practitioner_ID_PV1_7 using 'ID/Practitioner' XCN: PV1.7 -%}
+{% evaluate Practitioner_ID_PV1_8 using 'ID/Practitioner' XCN: PV1.8 -%}
+{% evaluate Practitioner_ID_PV1_9 using 'ID/Practitioner' XCN: PV1.9 -%}
+{% evaluate Practitioner_ID_PV1_17 using 'ID/Practitioner' XCN: PV1.17 -%}
+{% evaluate Practitioner_ID_PV1_52 using 'ID/Practitioner' XCN: PV1.52 -%}
+
 {
     "fullUrl":"urn:uuid:{{ ID }}",
     "resource":{

--- a/data/Templates/Hl7v2/Resource/_Immunization.liquid
+++ b/data/Templates/Hl7v2/Resource/_Immunization.liquid
@@ -9,6 +9,11 @@ Immunization_Patient_ID: A resource Id, used to fill "patient.reference" propert
 Immunization_Encounter_ID: A resource Id, used to fill "encounter.reference" property.
 {% endcomment -%}
 
+{% evaluate Practitioner_ID_ORC_12 using 'ID/Practitioner' XCN: ORC.12 -%}
+{% evaluate Organization_ID_RXA_17 using 'ID/Organization' CWE: RXA.17 -%}
+{% evaluate Location_ID_RXA_27 using 'ID/Location' CWE: RXA.27 -%}
+{% evaluate Practitioner_ID_RXA_10 using 'ID/Practitioner' XCN: RXA.10 -%}
+
 {
     "fullUrl":"urn:uuid:{{ ID }}",
     "resource":{

--- a/data/Templates/Hl7v2/Resource/_Observation.liquid
+++ b/data/Templates/Hl7v2/Resource/_Observation.liquid
@@ -9,6 +9,10 @@ Observation_Encounter_ID: A resource Id, used to fill "encounter.reference" prop
 Observation_Specimen_ID: A resource Id, used to fill "specimen.reference" property.
 {% endcomment -%}
 
+{% evaluate Practitioner_ID_OBX_16 using 'ID/Practitioner' XCN: OBX.16 -%}
+{% evaluate Organization_ID_OBX_23 using 'ID/Organization' XON: OBX.23 -%}
+{% evaluate PractitionerRole_ID_OBX_25 using 'ID/PractitionerRole' XCN: OBX.25 -%}
+
 {
     "fullUrl":"urn:uuid:{{ ID }}",
     "resource":{

--- a/data/Templates/Hl7v2/Resource/_Patient.liquid
+++ b/data/Templates/Hl7v2/Resource/_Patient.liquid
@@ -7,6 +7,8 @@ Organization_ID_NK1_13: A resource Id, used to fill "contact.organization.refere
 Patient_ManagingOrganization_ID: A resource Id, used to fill "managingOrganization.reference" property.
 {% endcomment -%}
 
+{% evaluate Organization_ID_NK1_13 using 'ID/Organization' XON: NK1.13 -%}
+
 {
     "fullUrl":"urn:uuid:{{ ID }}",
     "resource":{

--- a/data/Templates/Hl7v2/Resource/_PractitionerRole.liquid
+++ b/data/Templates/Hl7v2/Resource/_PractitionerRole.liquid
@@ -8,6 +8,9 @@ Organization_ID_PRT_8: A resource Id, used to fill "organization.reference" prop
 Organization_ID_ORC_21: A resource Id, used to fill "organization.reference" property. The resource is of "Organization" type and generated based on "ORC.21" HL7 V2 identifier.
 {% endcomment -%}
 
+{% evaluate Practitioner_ID_OBX_16 using 'ID/Practitioner' XCN: OBX.16 -%}
+{% evaluate Organization_ID_OBX_23 using 'ID/Organization' XON: OBX.23 -%}
+
 {
     "fullUrl":"urn:uuid:{{ ID }}",
     "resource":{

--- a/data/Templates/Hl7v2/Resource/_Provenance.liquid
+++ b/data/Templates/Hl7v2/Resource/_Provenance.liquid
@@ -4,11 +4,17 @@ The following reference IDs are accepted by this template.
 Organization_ID_MSH_4: A resource Id, used to fill "agent.who.reference" property. The resource is of "Organization" type and generated based on "MSH.4" HL7 V2 identifier.
 Organization_ID_MSH_22: A resource Id, used to fill "agent.who.reference" property. The resource is of "Organization" type and generated based on "MSH.22" HL7 V2 identifier.
 Practitioner_ID_ORC_10: A resource Id, used to fill "agent.who.reference" property. The resource is of "Practitioner" type and generated based on "ORC.10" HL7 V2 identifier.
-Organization_ID_ORC_17: A resource Id, used to fill "agent.who.onBehalfOf" property. The resource is of "Organization" type and generated based on "ORC.17" HL7 V2 identifier.
 Practitioner_ID_ORC_11: A resource Id, used to fill "agent.who.onBehalfOf" property. The resource is of "Practitioner" type and generated based on "ORC.11" HL7 V2 identifier.
 Practitioner_ID_ORC_12: A resource Id, used to fill "agent.who.onBehalfOf" property. The resource is of "Practitioner" type and generated based on "ORC.12" HL7 V2 identifier.
+Organization_ID_ORC_17: A resource Id, used to fill "agent.who.onBehalfOf" property. The resource is of "Organization" type and generated based on "ORC.17" HL7 V2 identifier.
 Location_ID_ORC_21: A resource Id, used to fill "location.onBehalfOf" property. The resource is of "Location" type and generated based on "ORC.21" HL7 V2 identifier.
 {% endcomment -%}
+
+{% evaluate Practitioner_ID_ORC_10 using 'ID/Practitioner' XCN: ORC.10 -%}
+{% evaluate Practitioner_ID_ORC_11 using 'ID/Practitioner' XCN: ORC.11 -%}
+{% evaluate Practitioner_ID_ORC_12 using 'ID/Practitioner' XCN: ORC.12 -%}
+{% evaluate Organization_ID_ORC_17 using 'ID/Organization' CWE: ORC.17 -%}
+{% evaluate Location_ID_ORC_21 using 'ID/Location' XON: ORC.21 -%}
 
 {
     "fullUrl":"urn:uuid:{{ ID }}",

--- a/data/Templates/Hl7v2/Resource/_ServiceRequest.liquid
+++ b/data/Templates/Hl7v2/Resource/_ServiceRequest.liquid
@@ -9,6 +9,9 @@ ServiceRequest_Subject_ID: A resource Id, used to fill "subject.reference" prope
 ServiceRequest_Encounter_ID: A resource Id, used to fill "encounter.reference" property.
 {% endcomment -%}
 
+{% evaluate Organization_ID_ORC_21 using 'ID/Organization' CWE: ORC.21 -%}
+{% evaluate Practitioner_ID_OBR_10 using 'ID/Practitioner' XCN: OBR.10 -%}
+
 {
     "fullUrl":"urn:uuid:{{ ID }}",
     "resource":{

--- a/data/Templates/Hl7v2/VXU_V04.liquid
+++ b/data/Templates/Hl7v2/VXU_V04.liquid
@@ -75,7 +75,7 @@
 
             {% evaluate immunizationId using 'ID/Immunization' ORC: orcSegment, baseId: patientId -%}
             {% assign fullImmunizationId = immunizationId | prepend: 'Immunization/' -%}
-            {% include 'Resource/Immunization' ORC: orcSegment, Immunization_Patient_ID: fullPatientId, Practitioner_ID_ORC_12: practitionerId_ORC_12, ID: immunizationId -%}
+            {% include 'Resource/Immunization' ORC: orcSegment, Immunization_Patient_ID: fullPatientId, ID: immunizationId -%}
 
             {% for rxaSegment in rxaSegmentLists.RXA -%}
                 {% assign obxSegmentLists = hl7v2Data | get_related_segment_list: rxaSegment, 'OBX' -%}
@@ -89,7 +89,7 @@
                 {% evaluate practitionerId_RXA_10 using 'ID/Practitioner' XCN: rxaSegment.10 -%}
                 {% include 'Resource/Practitioner' RXA: rxaSegment, ID: practitionerId_RXA_10 -%}
 
-                {% include 'Resource/Immunization' RXA: rxaSegment, Practitioner_ID_RXA_10: practitionerId_RXA_10, Organization_ID_RXA_17: organizationId_RXA_17, Location_ID_RXA_27: locationId_RXA_27, ID: immunizationId -%}
+                {% include 'Resource/Immunization' RXA: rxaSegment, ID: immunizationId -%}
 
                 {% for obxSegment in obxSegmentLists.OBX -%}
                     {% evaluate organizationId_OBX_23 using 'ID/Organization' XON: obxSegment.23 -%}

--- a/data/Templates/Hl7v2/VXU_V04.liquid
+++ b/data/Templates/Hl7v2/VXU_V04.liquid
@@ -61,7 +61,7 @@
             {% evaluate organizationId_NK1_13 using 'ID/Organization' XON: nk1Segment.13 -%}
             {% include 'Resource/Organization' NK1: nk1Segment, ID: organizationId_NK1_13 -%}
 
-            {% include 'Resource/Patient' NK1: nk1Segment, Organization_ID_NK1_13: organizationId_NK1_13, ID: patientId -%}
+            {% include 'Resource/Patient' NK1: nk1Segment, ID: patientId -%}
 
             {% evaluate relatedPersonId using 'ID/RelatedPerson' NK1: nk1Segment, baseId: patientId -%}
             {% include 'Resource/RelatedPerson' NK1: nk1Segment, RelatedPerson_Patient_ID: fullPatientId, ID: relatedPersonId -%}

--- a/data/Templates/Hl7v2/VXU_V04.liquid
+++ b/data/Templates/Hl7v2/VXU_V04.liquid
@@ -104,7 +104,7 @@
 
                     {% evaluate practitionerRoleId_OBX_25 using 'ID/PractitionerRole' XCN: obxSegment.25 -%}
                     {% if obxSegment.16 or obxSegment.23 or obxSegment.25 -%}
-                        {% include 'Resource/PractitionerRole' OBX: obxSegment, Practitioner_ID_OBX_16: practitionerId_OBX_16, Organization_ID_OBX_23: organizationId_OBX_23, ID: practitionerRoleId_OBX_25 -%}
+                        {% include 'Resource/PractitionerRole' OBX: obxSegment, ID: practitionerRoleId_OBX_25 -%}
                     {% endif -%}
 
                     {% evaluate deviceId_OBX_18 using 'ID/Device' HD: obxSegment.18 -%}

--- a/data/Templates/Hl7v2/VXU_V04.liquid
+++ b/data/Templates/Hl7v2/VXU_V04.liquid
@@ -113,7 +113,7 @@
                     {% endif -%}
 
                     {% evaluate observationId using 'ID/Observation' OBX: obxSegment, baseId: patientId -%}
-                    {% include 'Resource/Observation' OBX: obxSegment, Observation_Subject_ID: fullPatientId, Practitioner_ID_OBX_16: practitionerId_OBX_16, PractitionerRole_ID_OBX_25: practitionerRoleId_OBX_25, Organization_ID_OBX_23: organizationId_OBX_23, ID: observationId -%}
+                    {% include 'Resource/Observation' OBX: obxSegment, Observation_Subject_ID: fullPatientId, ID: observationId -%}
                     {% include 'Reference/Observation/PartOf' ID: observationId, REF: fullImmunizationId -%}
                 {% endfor -%}
             {% endfor -%}

--- a/data/Templates/Hl7v2/VXU_V04.liquid
+++ b/data/Templates/Hl7v2/VXU_V04.liquid
@@ -47,7 +47,7 @@
         {% include 'Resource/Location' PL: firstSegments.PV1.6, ID: locationId3_PV1_6 -%}
 
         {% evaluate provenanceId using 'ID/Provenance' MSH: firstSegments.MSH, baseId: patientId -%}
-        {% include 'Resource/Provenance' Root_Template: 'VXU_V04', MSH: firstSegments.MSH, ORC: firstSegments.ORC, Practitioner_ID_ORC_10: practitionerId10_ORC_10, Practitioner_ID_ORC_11: practitionerId10_ORC_11, Practitioner_ID_ORC_12: practitionerId10_ORC_12, Location_ID_ORC_21: locationId_ORC_21, ID: provenanceId -%}
+        {% include 'Resource/Provenance' Root_Template: 'VXU_V04', MSH: firstSegments.MSH, ORC: firstSegments.ORC, ID: provenanceId -%}
 
         {% evaluate accountId using 'ID/Account' CX: firstSegments.PID.3 -%}
         {% include 'Resource/Account' PID: firstSegments.PID, ID: accountId -%}

--- a/data/Templates/Hl7v2/VXU_V04.liquid
+++ b/data/Templates/Hl7v2/VXU_V04.liquid
@@ -54,7 +54,7 @@
         {% include 'Reference/Account/Subject' ID: accountId, REF: fullPatientId -%}
 
         {% evaluate encounterId using 'ID/Encounter' PV1: firstSegments.PV1, baseId: patientId -%}
-        {% include 'Resource/Encounter' PV1: firstSegments.PV1, PV2: firstSegments.PV2, Location_ID_PV1_3: locationId3_PV1_3, Location_ID_PV1_6: locationId3_PV1_6, Practitioner_ID_PV1_7: practitionerId7_PV1_7, Practitioner_ID_PV1_8: practitionerId7_PV1_8, Practitioner_ID_PV1_9: practitionerId7_PV1_9, Practitioner_ID_PV1_17: practitionerId7_PV1_17, Practitioner_ID_PV1_52: practitionerId7_PV1_52, ID: encounterId -%}
+        {% include 'Resource/Encounter' PV1: firstSegments.PV1, PV2: firstSegments.PV2, ID: encounterId -%}
         {% include 'Reference/Encounter/Subject' ID: encounterId, REF: fullPatientId -%}
 
         {% for nk1Segment in nk1SegmentLists.NK1 -%}

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/OML_O21/MDHHS-OML-O21-2-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/OML_O21/MDHHS-OML-O21-2-expected.json
@@ -505,6 +505,9 @@
                   "system": "http://terminology.hl7.org/CodeSystem/provenance-participant-type"
                 }
               ]
+            },
+            "who": {
+              "reference": "Practitioner/0ac4aa7e-de74-bd40-3b64-97a1c0f3a414"
             }
           }
         ],
@@ -518,6 +521,9 @@
           ]
         },
         "occurredDateTime": "2016-02-23T22:37:05+08:00",
+        "location": {
+          "reference": "Location/8d21e8ca-50c4-05e7-edb8-9f74c624369e"
+        },
         "target": [
           {
             "reference": "ServiceRequest/bafe469c-5cc7-f800-feae-81b33cf36940"

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/VXU_V04/VXU-expected.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.FunctionalTests/TestData/Expected/Hl7v2/VXU_V04/VXU-expected.json
@@ -259,6 +259,9 @@
             },
             "who": {
               "reference": "Practitioner/9d113ef1-15cf-ec5c-6e04-230bf6b8bf71"
+            },
+            "onBehalfOf": {
+              "reference": "Organization/a5fe12ca-fd28-0fba-c0f7-b103adb9eb92"
             }
           },
           {


### PR DESCRIPTION
* Move reference ID evaluation statements inside resource tempaltes to simplify usage.
* Performance test results are [here](https://microsoftapc.sharepoint.com/:f:/t/CompassTeam/Ep-xcAK04zpCgv9U1f0OIfIBeJLzeDbrwIXFJapycOSrdA?e=5m55PY). The total performance is slightly improved.