### PR TITLE
Add file-to-file option in command-line tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Here are the parameters that the tool accepts:
 | -d | TemplateDirectory | Required | | Root directory of templates. |
 | -r | RootTemplate | Required | | Name of root template. Valid values are ADT_A01, OML_O21, ORU_R01, VXU_V04. |
 | -c | InputDataContent | Optional| | Input data content. Specify OutputDataFile to get the results. |
+| -n | InputDataFile | Optional| | Input data file. Specify OutputDataFile to get the results. |
 | -f | OutputDataFile | Optional | | Output data file. |
 | -i | InputDataFolder | Optional | | Input data folder. Specify OutputDataFolder to get the results. |
 | -o | OutputDataFolder | Optional | | Output data folder. |

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/ConverterLogicHandler.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/ConverterLogicHandler.cs
@@ -36,6 +36,11 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Tool
             {
                 ConvertSingleFile(dataProcessor, templateProvider, dataType, options.RootTemplate, options.InputDataContent, options.OutputDataFile, options.IsTraceInfo);
             }
+            else if (!string.IsNullOrEmpty(options.InputDataFile))
+            {
+                var fileContent = File.ReadAllText(options.InputDataFile);
+                ConvertSingleFile(dataProcessor, templateProvider, dataType, options.RootTemplate, fileContent, options.OutputDataFile, options.IsTraceInfo);
+            }
             else
             {
                 ConvertBatchFiles(dataProcessor, templateProvider, dataType, options.RootTemplate, options.InputDataFolder, options.OutputDataFolder, options.IsTraceInfo);
@@ -140,17 +145,31 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Tool
         private static bool IsValidOptions(ConverterOptions options)
         {
             var contentToFile = !string.IsNullOrEmpty(options.InputDataContent) &&
-                !string.IsNullOrEmpty(options.OutputDataFile) &&
-                string.IsNullOrEmpty(options.InputDataFolder) &&
-                string.IsNullOrEmpty(options.OutputDataFolder);
+                                string.IsNullOrEmpty(options.InputDataFile) &&
+                                !string.IsNullOrEmpty(options.OutputDataFile) &&
+                                string.IsNullOrEmpty(options.InputDataFolder) &&
+                                string.IsNullOrEmpty(options.OutputDataFolder);
+
+            var fileToFile = string.IsNullOrEmpty(options.InputDataContent) &&
+                                !string.IsNullOrEmpty(options.InputDataFile) &&
+                                !string.IsNullOrEmpty(options.OutputDataFile) &&
+                                string.IsNullOrEmpty(options.InputDataFolder) &&
+                                string.IsNullOrEmpty(options.OutputDataFolder) &&
+                                !IsSameFile(options.InputDataFile, options.OutputDataFile);
 
             var folderToFolder = string.IsNullOrEmpty(options.InputDataContent) &&
-                string.IsNullOrEmpty(options.OutputDataFile) &&
-                !string.IsNullOrEmpty(options.InputDataFolder) &&
-                !string.IsNullOrEmpty(options.OutputDataFolder) &&
-                !IsSameDirectory(options.InputDataFolder, options.OutputDataFolder);
+                                 string.IsNullOrEmpty(options.InputDataFile) &&
+                                 string.IsNullOrEmpty(options.OutputDataFile) &&
+                                 !string.IsNullOrEmpty(options.InputDataFolder) &&
+                                 !string.IsNullOrEmpty(options.OutputDataFolder) &&
+                                 !IsSameDirectory(options.InputDataFolder, options.OutputDataFolder);
 
-            return contentToFile || folderToFolder;
+            return contentToFile || fileToFile || folderToFolder;
+        }
+
+        private static bool IsSameFile(string inputFile, string outputFile)
+        {
+            return string.Equals(inputFile, outputFile, StringComparison.InvariantCultureIgnoreCase);
         }
 
         private static bool IsSameDirectory(string inputFolder, string outputFolder)

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Models/ConverterOptions.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/Models/ConverterOptions.cs
@@ -19,6 +19,9 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Tool.Models
         [Option('c', "InputDataContent", Required = false, HelpText = "Input data content. Please specify OutputDataFile to get the results.")]
         public string InputDataContent { get; set; }
 
+        [Option('n', "InputDataFile", Required = false, HelpText = "Input data file. Please specify OutputDataFile to get the results.")]
+        public string InputDataFile { get; set; }
+
         [Option('f', "OutputDataFile", Required = false, HelpText = "Output data file")]
         public string OutputDataFile { get; set; }
 


### PR DESCRIPTION
For VS Code extension, the C-CDA input files are too large to be passed as command-line argument, so we add a file-to-file conversion option.