### PR TITLE
FHIR server has Account "status" as a mandatory field. It is missing in template.

### DIFF
--- a/data/Templates/Hl7v2/Resource/_Account.liquid
+++ b/data/Templates/Hl7v2/Resource/_Account.liquid
@@ -7,6 +7,11 @@
         [
             { {% include 'DataType/CX' CX: PID.18 -%} },
         ],
+        {% if PID.18 %}
+        "status": "active",
+        {% else %}
+        "status": "unknown",
+        {% endif %}
         "subject":
         [
             {% comment -%} Placeholder provided for customization by users. If left empty, it will be removed in post-processing. {% endcomment -%}


### PR DESCRIPTION
Without it, it has errors if I load converted data to FHIR server.