### PR TITLE
Make all parsers return same data structure in converter engine

### DIFF
--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Ccda/CcdaDataParserTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Ccda/CcdaDataParserTests.cs
@@ -47,10 +47,10 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Ccda
         public void GivenValidCcdaDocument_WhenParse_CorrectResultShouldBeReturned()
         {
             // Sample CCD document
-            var document = File.ReadAllText(Path.Join(Constants.SampleDataDirectory, "Ccda", "CCD.ccda"));
+            var document = File.ReadAllText(Path.Join(TestConstants.SampleDataDirectory, "Ccda", "CCD.ccda"));
             var data = CcdaDataParser.Parse(document);
             Assert.NotNull(data);
-            Assert.NotNull(((Dictionary<string, object>)data).GetValueOrDefault("msg"));
+            Assert.NotNull(((Dictionary<string, object>)data).GetValueOrDefault(Constants.CcdaDataKey));
 
             // Document that contains redundant namespaces "xmlns:cda"
             // It is removed in the parsed data
@@ -59,7 +59,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Ccda
             data = CcdaDataParser.Parse(document);
             var contents =
                 ((data as Dictionary<string, object>)
-                ?.GetValueOrDefault("msg") as Dictionary<string, object>)
+                ?.GetValueOrDefault(Constants.CcdaDataKey) as Dictionary<string, object>)
                 ?.GetValueOrDefault("ClinicalDocument") as Dictionary<string, object>;
             Assert.Equal(3, contents?.Count);
             Assert.Equal("http://www.w3.org/2001/XMLSchema-instance", contents?["xmlns:xsi"]);
@@ -74,7 +74,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Ccda
             data = CcdaDataParser.Parse(document);
             contents =
                 ((data as Dictionary<string, object>)
-                    ?.GetValueOrDefault("msg") as Dictionary<string, object>)
+                    ?.GetValueOrDefault(Constants.CcdaDataKey) as Dictionary<string, object>)
                 ?.GetValueOrDefault("ClinicalDocument") as Dictionary<string, object>;
             Assert.NotNull(contents?["sdtc_raceCode"]);
         }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Ccda/CcdaTemplateProviderTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Ccda/CcdaTemplateProviderTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Ccda
         public void GivenATemplateDirectory_WhenLoadTemplates_CorrectResultsShouldBeReturned()
         {
             // Valid template directory
-            var templateProvider = new CcdaTemplateProvider(Constants.CcdaTemplateDirectory);
+            var templateProvider = new CcdaTemplateProvider(TestConstants.CcdaTemplateDirectory);
             Assert.NotNull(templateProvider.GetTemplate("CCD"));
 
             // Invalid template directory

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/DotLiquids/EvaluateTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/DotLiquids/EvaluateTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.DotLiquids
             Assert.True(template.Root.NodeList.Count > 0);
 
             // Template should be rendered correctly
-            var templateProvider = new Hl7v2TemplateProvider(Constants.Hl7v2TemplateDirectory);
+            var templateProvider = new Hl7v2TemplateProvider(TestConstants.Hl7v2TemplateDirectory);
             var context = new Context(
                 environments: new List<Hash>(),
                 outerScope: new Hash(),
@@ -86,7 +86,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.DotLiquids
 
             // Valid template file system but no such template
             template = TemplateUtility.ParseTemplate(TemplateName, @"{% evaluate bundleId using 'ID/Foo' Data: hl7v2Data -%}");
-            var templateProvider = new Hl7v2TemplateProvider(Constants.Hl7v2TemplateDirectory);
+            var templateProvider = new Hl7v2TemplateProvider(TestConstants.Hl7v2TemplateDirectory);
             context = new Context(
                 environments: new List<Hash>(),
                 outerScope: new Hash(),

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/DotLiquids/TemplateLocalFileSystemTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/DotLiquids/TemplateLocalFileSystemTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.DotLiquids
         [Fact]
         public void GivenAValidTemplateDirectory_WhenGetTemplate_CorrectResultsShouldBeReturned()
         {
-            var templateLocalFileSystem = new TemplateLocalFileSystem(Constants.Hl7v2TemplateDirectory, DataType.Hl7v2);
+            var templateLocalFileSystem = new TemplateLocalFileSystem(TestConstants.Hl7v2TemplateDirectory, DataType.Hl7v2);
             var context = new Context(CultureInfo.InvariantCulture);
 
             // Template exists
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.DotLiquids
         [Fact]
         public void GivenAValidTemplateDirectory_WhenGetTemplateWithContext_CorrectResultsShouldBeReturned()
         {
-            var templateLocalFileSystem = new TemplateLocalFileSystem(Constants.Hl7v2TemplateDirectory, DataType.Hl7v2);
+            var templateLocalFileSystem = new TemplateLocalFileSystem(TestConstants.Hl7v2TemplateDirectory, DataType.Hl7v2);
             var context = new Context(CultureInfo.InvariantCulture);
 
             // Template exists
@@ -47,7 +47,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.DotLiquids
         [Fact]
         public void GivenAValidTemplateDirectory_WhenReadTemplateWithContext_ExceptionShouldBeThrown()
         {
-            var templateLocalFileSystem = new TemplateLocalFileSystem(Constants.Hl7v2TemplateDirectory, DataType.Hl7v2);
+            var templateLocalFileSystem = new TemplateLocalFileSystem(TestConstants.Hl7v2TemplateDirectory, DataType.Hl7v2);
             var context = new Context(CultureInfo.InvariantCulture);
             context["ADT_A01"] = "ADT_A01";
             Assert.Throws<NotImplementedException>(() => templateLocalFileSystem.ReadTemplateFile(context, "hello"));

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/SectionFiltersTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/SectionFiltersTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.FilterTests
 
             // Empty section name content
             var data = LoadTestData() as Dictionary<string, object>;
-            var msg = data?.GetValueOrDefault("msg") as IDictionary<string, object>;
+            var msg = data?.GetValueOrDefault(Constants.CcdaDataKey) as IDictionary<string, object>;
             Assert.Empty(Filters.GetFirstCcdaSections(Hash.FromDictionary(msg), string.Empty));
 
             // Valid data and section name content
@@ -47,7 +47,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.FilterTests
 
             // Empty section name content
             var data = LoadTestData() as Dictionary<string, object>;
-            var msg = data?.GetValueOrDefault("msg") as IDictionary<string, object>;
+            var msg = data?.GetValueOrDefault(Constants.CcdaDataKey) as IDictionary<string, object>;
             Assert.Empty(Filters.GetCcdaSectionLists(Hash.FromDictionary(msg), string.Empty));
 
             // Valid data and section name content
@@ -73,7 +73,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.FilterTests
 
             // Empty template id content
             var data = LoadTestData() as Dictionary<string, object>;
-            var msg = data?.GetValueOrDefault("msg") as IDictionary<string, object>;
+            var msg = data?.GetValueOrDefault(Constants.CcdaDataKey) as IDictionary<string, object>;
             Assert.Empty(Filters.GetFirstCcdaSectionsByTemplateId(Hash.FromDictionary(msg), string.Empty));
 
             // Valid data and template id content
@@ -88,7 +88,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.FilterTests
 
         private static IDictionary<string, object> LoadTestData()
         {
-            var dataContent = File.ReadAllText(Path.Join(Constants.SampleDataDirectory, "Ccda", "170.314B2_Amb_CCD.ccda"));
+            var dataContent = File.ReadAllText(Path.Join(TestConstants.SampleDataDirectory, "Ccda", "170.314B2_Amb_CCD.ccda"));
             return CcdaDataParser.Parse(dataContent);
         }
     }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/SegmentFiltersTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/SegmentFiltersTests.cs
@@ -121,7 +121,8 @@ RXA|0|1|20131112||88^influenza, unspecified formulation^CVX|999|||01^Historical 
 
         private static Hl7v2Data LoadTestData()
         {
-            return Hl7v2DataParser.Parse(TestData);
+            var data = Hl7v2DataParser.Parse(TestData);
+            return data["hl7v2Data"] as Hl7v2Data;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/SegmentFiltersTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/SegmentFiltersTests.cs
@@ -122,7 +122,7 @@ RXA|0|1|20131112||88^influenza, unspecified formulation^CVX|999|||01^Historical 
         private static Hl7v2Data LoadTestData()
         {
             var data = Hl7v2DataParser.Parse(TestData);
-            return data[Hl7v2DataParser.Hl7v2DataKey] as Hl7v2Data;
+            return data[Constants.Hl7v2DataKey] as Hl7v2Data;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/SegmentFiltersTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/SegmentFiltersTests.cs
@@ -122,7 +122,7 @@ RXA|0|1|20131112||88^influenza, unspecified formulation^CVX|999|||01^Historical 
         private static Hl7v2Data LoadTestData()
         {
             var data = Hl7v2DataParser.Parse(TestData);
-            return data["hl7v2Data"] as Hl7v2Data;
+            return data[Hl7v2DataParser.Hl7v2DataKey] as Hl7v2Data;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Hl7v2DataParserTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Hl7v2DataParserTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Hl7v2
 NK1|1|JOHNSON^CONWAY^^^^^L|SPOUS||(130) 724-0433^PRN^PH^^^431^2780404~(330) 274-8214^ORN^PH^^^330^2748214||EMERGENCY
 ||E|||||12345^Johnson^Peter|||||||||||||||||||||||||||||||||||||201905020700";
 
-            var hl7v2Data = Hl7v2DataParser.Parse(input)[Hl7v2DataParser.Hl7v2DataKey] as Hl7v2Data;
+            var hl7v2Data = Hl7v2DataParser.Parse(input)[Constants.Hl7v2DataKey] as Hl7v2Data;
             Assert.Equal(3, hl7v2Data.Meta.Count);
             Assert.Equal("MSH", hl7v2Data.Meta[0]);
             Assert.Equal("NK1", hl7v2Data.Meta[1]);

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Hl7v2DataParserTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Hl7v2DataParserTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Hl7v2
 NK1|1|JOHNSON^CONWAY^^^^^L|SPOUS||(130) 724-0433^PRN^PH^^^431^2780404~(330) 274-8214^ORN^PH^^^330^2748214||EMERGENCY
 ||E|||||12345^Johnson^Peter|||||||||||||||||||||||||||||||||||||201905020700";
 
-            var hl7v2Data = Hl7v2DataParser.Parse(input)["hl7v2Data"] as Hl7v2Data;
+            var hl7v2Data = Hl7v2DataParser.Parse(input)[Hl7v2DataParser.Hl7v2DataKey] as Hl7v2Data;
             Assert.Equal(3, hl7v2Data.Meta.Count);
             Assert.Equal("MSH", hl7v2Data.Meta[0]);
             Assert.Equal("NK1", hl7v2Data.Meta[1]);

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Hl7v2DataParserTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Hl7v2DataParserTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Hl7v2
 NK1|1|JOHNSON^CONWAY^^^^^L|SPOUS||(130) 724-0433^PRN^PH^^^431^2780404~(330) 274-8214^ORN^PH^^^330^2748214||EMERGENCY
 ||E|||||12345^Johnson^Peter|||||||||||||||||||||||||||||||||||||201905020700";
 
-            var hl7v2Data = Hl7v2DataParser.Parse(input);
+            var hl7v2Data = Hl7v2DataParser.Parse(input)["hl7v2Data"] as Hl7v2Data;
             Assert.Equal(3, hl7v2Data.Meta.Count);
             Assert.Equal("MSH", hl7v2Data.Meta[0]);
             Assert.Equal("NK1", hl7v2Data.Meta[1]);

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Hl7v2TemplateProviderTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Hl7v2TemplateProviderTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Hl7v2
         public void GivenATemplateDirectory_WhenLoadTemplates_CorrectResultsShouldBeReturned()
         {
             // Valid template directory
-            var templateProvider = new Hl7v2TemplateProvider(Constants.Hl7v2TemplateDirectory);
+            var templateProvider = new Hl7v2TemplateProvider(TestConstants.Hl7v2TemplateDirectory);
             Assert.NotNull(templateProvider.GetTemplate("ADT_A01"));
 
             // Invalid template directory

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Models/Hl7v2TraceInfoTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Models/Hl7v2TraceInfoTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Hl7v2.Models
             // Valid Hl7v2Data before render
             var content = @"MSH|^~\&|AccMgr|1|||20050110045504||ADT^A01|599102|P|2.3||| 
 PID|1||10006579^^^1^MR^1||DUCK^DONALD^D||19241010|M||1|111 DUCK ST^^FOWL^CA^999990000^^M|1|8885551212|8885551212|1|2||40007716^^^AccMgr^VN^1|123121234|||||||||||NO ";
-            data = Hl7v2DataParser.Parse(content)[Hl7v2DataParser.Hl7v2DataKey] as Hl7v2Data;
+            data = Hl7v2DataParser.Parse(content)[Constants.Hl7v2DataKey] as Hl7v2Data;
             traceInfo = Hl7v2TraceInfo.CreateTraceInfo(data);
             Assert.Equal(2, traceInfo.UnusedSegments.Count);
             Assert.Equal(27, traceInfo.UnusedSegments[1].Components.Count);
@@ -57,7 +57,7 @@ PID|1||10006579^^^1^MR^1||DUCK^DONALD^D||19241010|M||1|111 DUCK ST^^FOWL^CA^9999
 
             // Valid Hl7v2Data after render
             var processor = new Hl7v2Processor();
-            var templateProvider = new Hl7v2TemplateProvider(Constants.Hl7v2TemplateDirectory);
+            var templateProvider = new Hl7v2TemplateProvider(TestConstants.Hl7v2TemplateDirectory);
             _ = processor.Convert(content, "ADT_A01", templateProvider, traceInfo);
             Assert.Single(traceInfo.UnusedSegments);
 

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Models/Hl7v2TraceInfoTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Models/Hl7v2TraceInfoTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Hl7v2.Models
             // Valid Hl7v2Data before render
             var content = @"MSH|^~\&|AccMgr|1|||20050110045504||ADT^A01|599102|P|2.3||| 
 PID|1||10006579^^^1^MR^1||DUCK^DONALD^D||19241010|M||1|111 DUCK ST^^FOWL^CA^999990000^^M|1|8885551212|8885551212|1|2||40007716^^^AccMgr^VN^1|123121234|||||||||||NO ";
-            data = Hl7v2DataParser.Parse(content)["hl7v2Data"] as Hl7v2Data;
+            data = Hl7v2DataParser.Parse(content)[Hl7v2DataParser.Hl7v2DataKey] as Hl7v2Data;
             traceInfo = Hl7v2TraceInfo.CreateTraceInfo(data);
             Assert.Equal(2, traceInfo.UnusedSegments.Count);
             Assert.Equal(27, traceInfo.UnusedSegments[1].Components.Count);

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Models/Hl7v2TraceInfoTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Hl7v2/Models/Hl7v2TraceInfoTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Hl7v2.Models
             // Valid Hl7v2Data before render
             var content = @"MSH|^~\&|AccMgr|1|||20050110045504||ADT^A01|599102|P|2.3||| 
 PID|1||10006579^^^1^MR^1||DUCK^DONALD^D||19241010|M||1|111 DUCK ST^^FOWL^CA^999990000^^M|1|8885551212|8885551212|1|2||40007716^^^AccMgr^VN^1|123121234|||||||||||NO ";
-            data = Hl7v2DataParser.Parse(content);
+            data = Hl7v2DataParser.Parse(content)["hl7v2Data"] as Hl7v2Data;
             traceInfo = Hl7v2TraceInfo.CreateTraceInfo(data);
             Assert.Equal(2, traceInfo.UnusedSegments.Count);
             Assert.Equal(27, traceInfo.UnusedSegments[1].Components.Count);

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/ProcessorTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/ProcessorTests.cs
@@ -23,14 +23,14 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests
 
         static ProcessorTests()
         {
-            _hl7v2TestData = File.ReadAllText(Path.Join(Constants.SampleDataDirectory, "Hl7v2", "LRI_2.0-NG_CBC_Typ_Message.hl7"));
-            _ccdaTestData = File.ReadAllText(Path.Join(Constants.SampleDataDirectory, "Ccda", "CCD.ccda"));
+            _hl7v2TestData = File.ReadAllText(Path.Join(TestConstants.SampleDataDirectory, "Hl7v2", "LRI_2.0-NG_CBC_Typ_Message.hl7"));
+            _ccdaTestData = File.ReadAllText(Path.Join(TestConstants.SampleDataDirectory, "Ccda", "CCD.ccda"));
         }
 
         public static IEnumerable<object[]> GetValidInputsWithTemplateDirectory()
         {
-            yield return new object[] { new Hl7v2Processor(), new Hl7v2TemplateProvider(Constants.Hl7v2TemplateDirectory), _hl7v2TestData, "ORU_R01", };
-            yield return new object[] { new CcdaProcessor(), new CcdaTemplateProvider(Constants.CcdaTemplateDirectory), _ccdaTestData, "CCD", };
+            yield return new object[] { new Hl7v2Processor(), new Hl7v2TemplateProvider(TestConstants.Hl7v2TemplateDirectory), _hl7v2TestData, "ORU_R01", };
+            yield return new object[] { new CcdaProcessor(), new CcdaTemplateProvider(TestConstants.CcdaTemplateDirectory), _ccdaTestData, "CCD", };
         }
 
         public static IEnumerable<object[]> GetValidInputsWithTemplateCollection()

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/TestConstants.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/TestConstants.cs
@@ -7,7 +7,7 @@ using System.IO;
 
 namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests
 {
-    public static class Constants
+    public static class TestConstants
     {
         public static readonly string SampleDataDirectory = Path.Join("..", "..", "data", "SampleData");
         public static readonly string TemplateDirectory = Path.Join("..", "..", "data", "Templates");

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/BaseProcessor.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/BaseProcessor.cs
@@ -30,17 +30,14 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
 
         public abstract string Convert(string data, string rootTemplate, ITemplateProvider templateProvider, TraceInfo traceInfo = null);
 
-        protected virtual Context CreateContext(ITemplateProvider templateProvider, object data)
+        protected virtual Context CreateContext(ITemplateProvider templateProvider, IDictionary<string, object> data)
         {
             // Load data and templates
             var timeout = _settings?.TimeOut ?? 0;
-            var dataDictionary = data is IDictionary<string, object> dictionary
-                ? dictionary
-                : new Dictionary<string, object>() { { "hl7v2Data", data } };
             var context = new Context(
-                environments: new List<Hash>() { Hash.FromDictionary(dataDictionary) },
+                environments: new List<Hash> { Hash.FromDictionary(data) },
                 outerScope: new Hash(),
-                registers: Hash.FromDictionary(new Dictionary<string, object>() { { "file_system", templateProvider.GetTemplateFileSystem() } }),
+                registers: Hash.FromDictionary(new Dictionary<string, object> { { "file_system", templateProvider.GetTemplateFileSystem() } }),
                 errorsOutputMode: ErrorsOutputMode.Rethrow,
                 maxIterations: 0,
                 timeout: timeout,

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Ccda/CcdaDataParser.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Ccda/CcdaDataParser.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Ccda
 
                 return new Dictionary<string, object>
                 {
-                    { "msg", dataDictionary },
+                    { Constants.CcdaDataKey, dataDictionary },
                 };
             }
             catch (Exception ex)

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Ccda/CcdaDataParser.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Ccda/CcdaDataParser.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Ccda
                 // Remove line breaks in original data
                 dataDictionary["_originalData"] = Regex.Replace(document, @"\r\n?|\n", string.Empty);
 
-                return new Dictionary<string, object>()
+                return new Dictionary<string, object>
                 {
                     { "msg", dataDictionary },
                 };

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Ccda/CcdaProcessor.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Ccda/CcdaProcessor.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using System.Linq;
 using DotLiquid;
 using Microsoft.Health.Fhir.Liquid.Converter.Exceptions;
@@ -45,7 +46,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Ccda
             return result.ToString(Formatting.Indented);
         }
 
-        protected override Context CreateContext(ITemplateProvider templateProvider, object ccdaData)
+        protected override Context CreateContext(ITemplateProvider templateProvider, IDictionary<string, object> ccdaData)
         {
             // Load value set mapping
             var context = base.CreateContext(templateProvider, ccdaData);

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Ccda/CcdaProcessor.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Ccda/CcdaProcessor.cs
@@ -46,10 +46,10 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Ccda
             return result.ToString(Formatting.Indented);
         }
 
-        protected override Context CreateContext(ITemplateProvider templateProvider, IDictionary<string, object> ccdaData)
+        protected override Context CreateContext(ITemplateProvider templateProvider, IDictionary<string, object> data)
         {
             // Load value set mapping
-            var context = base.CreateContext(templateProvider, ccdaData);
+            var context = base.CreateContext(templateProvider, data);
             var codeMapping = templateProvider.GetTemplate("ValueSet/ValueSet");
             if (codeMapping?.Root?.NodeList?.First() != null)
             {

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Constants.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Constants.cs
@@ -1,0 +1,13 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Liquid.Converter
+{
+    public static class Constants
+    {
+        public const string Hl7v2DataKey = "hl7v2Data";
+        public const string CcdaDataKey = "msg";
+    }
+}

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/DotLiquids/IFhirConverterTemplateFileSystem.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/DotLiquids/IFhirConverterTemplateFileSystem.cs
@@ -6,7 +6,7 @@
 using DotLiquid;
 using DotLiquid.FileSystems;
 
-namespace Microsoft.Health.Fhir.Liquid.Converter
+namespace Microsoft.Health.Fhir.Liquid.Converter.DotLiquids
 {
     public interface IFhirConverterTemplateFileSystem : ITemplateFileSystem
     {

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/CollectionFilters.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/CollectionFilters.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using DotLiquid;
+using Microsoft.Health.Fhir.Liquid.Converter.DotLiquids;
 using Microsoft.Health.Fhir.Liquid.Converter.Exceptions;
 using Microsoft.Health.Fhir.Liquid.Converter.Models;
 

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Hl7v2DataParser.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Hl7v2DataParser.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2
         private static readonly Hl7v2DataValidator Validator = new Hl7v2DataValidator();
         private static readonly string[] SegmentSeparators = { "\r\n", "\r", "\n" };
 
-        public static Hl7v2Data Parse(string message)
+        public static IDictionary<string, object> Parse(string message)
         {
             if (string.IsNullOrEmpty(message))
             {
@@ -42,7 +42,10 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2
                     result.Data.Add(segment);
                 }
 
-                return result;
+                return new Dictionary<string, object>
+                {
+                    { "hl7v2Data", result },
+                };
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Hl7v2DataParser.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Hl7v2DataParser.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2
 {
     public static class Hl7v2DataParser
     {
+        public const string Hl7v2DataKey = "hl7v2Data";
         private static readonly Hl7v2DataValidator Validator = new Hl7v2DataValidator();
         private static readonly string[] SegmentSeparators = { "\r\n", "\r", "\n" };
 
@@ -44,7 +45,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2
 
                 return new Dictionary<string, object>
                 {
-                    { "hl7v2Data", result },
+                    { Hl7v2DataKey, result },
                 };
             }
             catch (Exception ex)

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Hl7v2DataParser.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Hl7v2DataParser.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2
 {
     public static class Hl7v2DataParser
     {
-        public const string Hl7v2DataKey = "hl7v2Data";
         private static readonly Hl7v2DataValidator Validator = new Hl7v2DataValidator();
         private static readonly string[] SegmentSeparators = { "\r\n", "\r", "\n" };
 
@@ -45,7 +44,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2
 
                 return new Dictionary<string, object>
                 {
-                    { Hl7v2DataKey, result },
+                    { Constants.Hl7v2DataKey, result },
                 };
             }
             catch (Exception ex)

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Hl7v2Processor.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Hl7v2Processor.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2
             var result = PostProcessor.Process(rawResult);
             if (traceInfo is Hl7v2TraceInfo hl7V2TraceInfo)
             {
-                hl7V2TraceInfo.UnusedSegments = Hl7v2TraceInfo.CreateTraceInfo(hl7v2Data[Hl7v2DataParser.Hl7v2DataKey] as Hl7v2Data).UnusedSegments;
+                hl7V2TraceInfo.UnusedSegments = Hl7v2TraceInfo.CreateTraceInfo(hl7v2Data[Constants.Hl7v2DataKey] as Hl7v2Data).UnusedSegments;
             }
 
             return result.ToString(Formatting.Indented);

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Hl7v2Processor.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Hl7v2Processor.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using System.Linq;
 using DotLiquid;
 using Microsoft.Health.Fhir.Liquid.Converter.Exceptions;
@@ -44,13 +45,13 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2
             var result = PostProcessor.Process(rawResult);
             if (traceInfo is Hl7v2TraceInfo hl7V2TraceInfo)
             {
-                hl7V2TraceInfo.UnusedSegments = Hl7v2TraceInfo.CreateTraceInfo(hl7v2Data).UnusedSegments;
+                hl7V2TraceInfo.UnusedSegments = Hl7v2TraceInfo.CreateTraceInfo(hl7v2Data["hl7v2Data"] as Hl7v2Data).UnusedSegments;
             }
 
             return result.ToString(Formatting.Indented);
         }
 
-        protected override Context CreateContext(ITemplateProvider templateProvider, object hl7v2Data)
+        protected override Context CreateContext(ITemplateProvider templateProvider, IDictionary<string, object> hl7v2Data)
         {
             // Load code system mapping
             var context = base.CreateContext(templateProvider, hl7v2Data);

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Hl7v2Processor.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Hl7v2Processor.cs
@@ -51,10 +51,10 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2
             return result.ToString(Formatting.Indented);
         }
 
-        protected override Context CreateContext(ITemplateProvider templateProvider, IDictionary<string, object> hl7v2Data)
+        protected override Context CreateContext(ITemplateProvider templateProvider, IDictionary<string, object> data)
         {
             // Load code system mapping
-            var context = base.CreateContext(templateProvider, hl7v2Data);
+            var context = base.CreateContext(templateProvider, data);
             var codeMapping = templateProvider.GetTemplate("CodeSystem/CodeSystem");
             if (codeMapping?.Root?.NodeList?.First() != null)
             {

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Hl7v2Processor.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Hl7v2/Hl7v2Processor.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Hl7v2
             var result = PostProcessor.Process(rawResult);
             if (traceInfo is Hl7v2TraceInfo hl7V2TraceInfo)
             {
-                hl7V2TraceInfo.UnusedSegments = Hl7v2TraceInfo.CreateTraceInfo(hl7v2Data["hl7v2Data"] as Hl7v2Data).UnusedSegments;
+                hl7V2TraceInfo.UnusedSegments = Hl7v2TraceInfo.CreateTraceInfo(hl7v2Data[Hl7v2DataParser.Hl7v2DataKey] as Hl7v2Data).UnusedSegments;
             }
 
             return result.ToString(Formatting.Indented);


### PR DESCRIPTION
Make all parsers return same data structure `IDictionary<string, object>` by moving logics for Hl7 v2 from `BaseProcessor` to `Hl7v2DataParser` in converter engine. Only code refinements and no behavior change.

Some other refinements:
- Add `Constants.cs` to hold constant keys for parsers
- Rename `Constants.cs` in unit tests to `TestConstants.cs`
- Refine namespace for `IFhirConverterTemplateFileSystem`