### PR TITLE
Remove unused library

### DIFF
--- a/release.yml
+++ b/release.yml
@@ -5,9 +5,9 @@ trigger:
 - master
 - dotliquid
 - refs/heads/dotliquid
-pr: ['dotliquid']
-
-
+pr:
+- dotliquid
+- main
 
 variables:
   solution: '**/*.sln'

--- a/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.Liquid.Converter.nuspec
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.Liquid.Converter.nuspec
@@ -19,7 +19,6 @@
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="3.1.9" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Options" version="5.0.0" exclude="Build,Analyzers" />
         <dependency id="Newtonsoft.Json" version="12.0.3" exclude="Build,Analyzers" />
-        <dependency id="RestSharp" version="106.11.5" exclude="Build,Analyzers" />
         <dependency id="SharpZipLib" version="1.3.0" exclude="Build,Analyzers" />
         <dependency id="StyleCop.Analyzers" version="1.1.118" exclude="Build,Analyzers" />
         <dependency id="System.Runtime" version="4.3.1" exclude="Build,Analyzers" />

--- a/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.TemplateManagement.csproj
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.TemplateManagement.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="RestSharp" Version="106.11.5" />
     <PackageReference Include="SharpCompress" Version="0.26.0" />
     <PackageReference Include="SharpZipLib" Version="1.3.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />


### PR DESCRIPTION
Remove RestSharp, which has a component governance alert of current version, and is never used in our repo.