### PR TITLE
Add support for JSON default templates

### DIFF
--- a/release.yml
+++ b/release.yml
@@ -149,7 +149,7 @@ stages:
   - job: Windows_Functional_Test
     pool:
         vmImage: 'windows-latest'
-    continueOnError: true
+    continueOnError: false
     steps:
     - checkout: none #skip checking out the default repository resource
     - task: DownloadBuildArtifacts@0

--- a/release.yml
+++ b/release.yml
@@ -14,10 +14,10 @@ variables:
   functionalTests: "**/*FunctionalTests/*.csproj"
   buildConfiguration: 'Release'
   major: 4
-  minor: 1
-  bulidnum: $[counter(format('{0}.{1}',variables['major'],variables['minor']), 100)]
-  revision: $[counter(format('{0:yyyyMMdd}', pipeline.startTime), 1)]
-  version: $(major).$(minor).$(bulidnum).$(revision)
+  minor: 2
+  patch: 0
+  buildnum: $[counter(format('{0}.{1}.{2}',variables['major'],variables['minor'], variables['patch']), 1)]
+  version: $(major).$(minor).$(patch).$(buildnum)
 
 stages:
 - stage: Build
@@ -88,7 +88,7 @@ stages:
         targetType: 'inline'
         script: |
           $targetPath = '$(Build.SourcesDirectory)/data/Templates/Hl7v2/Resource/_Provenance.liquid'
-          (Get-Content $targetPath).replace('TEMPLATE_VERSION_PLACEHOLDER', '$(major).$(minor)') | Set-Content $targetPath
+          (Get-Content $targetPath).replace('TEMPLATE_VERSION_PLACEHOLDER', '$(major).$(minor).$(patch)') | Set-Content $targetPath
 
     - task: ArchiveFiles@2
       inputs:
@@ -105,6 +105,14 @@ stages:
         archiveType: 'tar'
         tarCompression: 'gz'
         archiveFile: '$(Build.SourcesDirectory)/data/Templates/CcdaDefaultTemplates.tar.gz'
+
+    - task: ArchiveFiles@2
+      inputs:
+        rootFolderOrFile: '$(Build.SourcesDirectory)/data/Templates/Json'
+        includeRootFolder: false
+        archiveType: 'tar'
+        tarCompression: 'gz'
+        archiveFile: '$(Build.SourcesDirectory)/data/Templates/JsonDefaultTemplates.tar.gz'
 
     - task: CopyFiles@2
       displayName: 'copy DefaultTemplates to artifacts'
@@ -222,8 +230,9 @@ stages:
         repositoryName: microsoft/FHIR-Converter
         isDraft: true
         tagSource: manual
-        tag: v$(major).$(minor).$(bulidnum)      
+        tag: v$(major).$(minor).$(patch)      
         assets: |
           $(System.DefaultWorkingDirectory)/FhirConverterBuild/bin/**
           $(System.DefaultWorkingDirectory)/FhirConverterBuild/data/Templates/Hl7v2DefaultTemplates.tar.gz
           $(System.DefaultWorkingDirectory)/FhirConverterBuild/data/Templates/CcdaDefaultTemplates.tar.gz
+          $(System.DefaultWorkingDirectory)/FhirConverterBuild/data/Templates/JsonDefaultTemplates.tar.gz

--- a/src/Microsoft.Health.Fhir.TemplateManagement.FunctionalTests/TemplateCollectionFunctionalTests.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement.FunctionalTests/TemplateCollectionFunctionalTests.cs
@@ -222,6 +222,11 @@ namespace Microsoft.Health.Fhir.TemplateManagement.FunctionalTests
         [MemberData(nameof(GetInvalidImageReference))]
         public void GiveInvalidImageReference_WhenGetTemplateCollection_ExceptionWillBeThrownAsync(string imageReference)
         {
+            if (_containerRegistryInfo == null)
+            {
+                return;
+            }
+
             TemplateCollectionProviderFactory factory = new TemplateCollectionProviderFactory(cache, Options.Create(_config));
             Assert.Throws<ImageReferenceException>(() => factory.CreateTemplateCollectionProvider(imageReference, token));
         }

--- a/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/Models/DefaultTemplateInfoTest.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/Models/DefaultTemplateInfoTest.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Health.Fhir.TemplateManagement.UnitTests
             yield return new object[] { DataType.Hl7v2, "microsofthealth/fhirconverter:default", "Hl7v2DefaultTemplates.tar.gz" };
             yield return new object[] { DataType.Hl7v2, "microsofthealth/hl7v2templates:default", "Hl7v2DefaultTemplates.tar.gz" };
             yield return new object[] { DataType.Ccda, "microsofthealth/ccdatemplates:default", "CcdaDefaultTemplates.tar.gz" };
+            yield return new object[] { DataType.Json, "microsofthealth/jsontemplates:default", "JsonDefaultTemplates.tar.gz" };
         }
 
         public static IEnumerable<object[]> GetSupportedImageReference()
@@ -25,6 +26,7 @@ namespace Microsoft.Health.Fhir.TemplateManagement.UnitTests
             yield return new object[] { "microsofthealth/fhirconverter:default" };
             yield return new object[] { "microsofthealth/hl7v2templates:default" };
             yield return new object[] { "microsofthealth/ccdatemplates:default" };
+            yield return new object[] { "microsofthealth/jsontemplates:default" };
         }
 
         public static IEnumerable<object[]> GetSupportedImageReferenceWithCaseInsensitive()
@@ -34,6 +36,7 @@ namespace Microsoft.Health.Fhir.TemplateManagement.UnitTests
             yield return new object[] { "microsofthealth/fhirconverter:Default" };
             yield return new object[] { "MICROSOFTHEALTH/hl7v2templates:default" };
             yield return new object[] { "microsofthealth/ccdatemplates:DEFAULT" };
+            yield return new object[] { "microsofthealth/JSONtemplates:DEFAULT" };
         }
 
         public static IEnumerable<object[]> GetUnSupportedImageReference()

--- a/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/Models/ImageInfoTest.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/Models/ImageInfoTest.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Health.Fhir.TemplateManagement.UnitTests
             yield return new object[] { "microsofthealth/fhirconverter:default" };
             yield return new object[] { "microsofthealth/hl7v2templates:default" };
             yield return new object[] { "microsofthealth/ccdatemplates:default" };
+            yield return new object[] { "microsofthealth/jsontemplates:default" };
         }
 
         public static IEnumerable<object[]> GetDefaultTemplateReferenceWithCaseInsensitive()
@@ -93,6 +94,7 @@ namespace Microsoft.Health.Fhir.TemplateManagement.UnitTests
             yield return new object[] { "MICROSOFTHEALTH/FHIRCONVERTER:DEFAULT" };
             yield return new object[] { "MicrosoftHealth/Hl7v2Templates:default" };
             yield return new object[] { "microsoftHealth/CcdaTemplates:default" };
+            yield return new object[] { "microsoftHealth/JSONTemplates:default" };
         }
 
         public static IEnumerable<object[]> GetInvalidDefaultTemplateReference()

--- a/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/Providers/TemplateCollectionProviderTests.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/Providers/TemplateCollectionProviderTests.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Health.Fhir.TemplateManagement.UnitTests.Providers
             _cache.Set("microsofthealth/hl7v2templates:default", hl7V2DefaultTemplateLayer, memoryOption);
             TemplateLayer ccdaDefaultTemplateLayer = TemplateLayer.ReadFromEmbeddedResource("CcdaDefaultTemplates.tar.gz");
             _cache.Set("microsofthealth/ccdatemplates:default", ccdaDefaultTemplateLayer, memoryOption);
+            TemplateLayer jsonDefaultTemplateLayer = TemplateLayer.ReadFromEmbeddedResource("JsonDefaultTemplates.tar.gz");
+            _cache.Set("microsofthealth/jsontemplates:default", jsonDefaultTemplateLayer, memoryOption);
 
             PushLargeSizeManifest();
         }
@@ -86,6 +88,7 @@ namespace Microsoft.Health.Fhir.TemplateManagement.UnitTests.Providers
             yield return new object[] { "microsofthealth/fhirconverter:default", 808 };
             yield return new object[] { "microsofthealth/hl7v2templates:default", 808 };
             yield return new object[] { "microsofthealth/ccdatemplates:default", 839 };
+            yield return new object[] { "microsofthealth/jsontemplates:default", 2 };
         }
 
         [Theory]

--- a/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/TemplateCollectionProviderFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/TemplateCollectionProviderFactoryTests.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Health.Fhir.TemplateManagement.UnitTests
         private static readonly string _defaultTemplateImageReference = "microsofthealth/fhirconverter:default";
         private static readonly string _defaultHl7v2TemplateImageReference = "microsofthealth/hl7v2templates:default";
         private static readonly string _defaultCcdaTemplateImageReference = "microsofthealth/ccdatemplates:default";
+        private static readonly string _defaultJsonTemplateImageReference = "microsofthealth/jsontemplates:default";
 
         public static IEnumerable<object[]> GetValidImageInfoWithTag()
         {
@@ -43,6 +44,7 @@ namespace Microsoft.Health.Fhir.TemplateManagement.UnitTests
             yield return new object[] { "NewDefaultTemplates.tar.gz", _defaultTemplateImageReference, Path.Join(_testTemplatesPath, "Hl7v2") };
             yield return new object[] { "Hl7v2NewDefaultTemplates.tar.gz", _defaultHl7v2TemplateImageReference, Path.Join(_testTemplatesPath, "Hl7v2") };
             yield return new object[] { "CcdaNewDefaultTemplates.tar.gz", _defaultCcdaTemplateImageReference, Path.Join(_testTemplatesPath, "Ccda") };
+            yield return new object[] { "JsonNewDefaultTemplates.tar.gz", _defaultJsonTemplateImageReference, Path.Join(_testTemplatesPath, "Json") };
         }
 
         public static IEnumerable<object[]> GetDefaultImageReference()
@@ -50,6 +52,7 @@ namespace Microsoft.Health.Fhir.TemplateManagement.UnitTests
             yield return new object[] { _defaultTemplateImageReference };
             yield return new object[] { _defaultHl7v2TemplateImageReference };
             yield return new object[] { _defaultCcdaTemplateImageReference };
+            yield return new object[] { _defaultJsonTemplateImageReference };
         }
 
         [Theory]

--- a/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.TemplateManagement.csproj
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.TemplateManagement.csproj
@@ -49,6 +49,9 @@
     <EmbeddedResource Include="$(BinFolder)CcdaDefaultTemplates.tar.gz">
       <Link>CcdaDefaultTemplates.tar.gz</Link>
     </EmbeddedResource>
+    <EmbeddedResource Include="$(BinFolder)JsonDefaultTemplates.tar.gz">
+      <Link>JsonDefaultTemplates.tar.gz</Link>
+    </EmbeddedResource>
   </ItemGroup>
 	
   <ItemGroup>
@@ -66,6 +69,7 @@
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="mkdir $(BinFolder) &amp; tar -zcvf $(BinFolder)Hl7v2DefaultTemplates.tar.gz -C $(DataFolder)Templates/Hl7v2 ." />
     <Exec Command="tar -zcvf $(BinFolder)CcdaDefaultTemplates.tar.gz -C $(DataFolder)Templates/Ccda ." />
+    <Exec Command="tar -zcvf $(BinFolder)JsonDefaultTemplates.tar.gz -C $(DataFolder)Templates/Json ." />
   </Target>
   
   <Target Name="DownloadWinOrasFile" BeforeTargets="Build">

--- a/src/Microsoft.Health.Fhir.TemplateManagement/Models/DefaultTemplateInfo.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Models/DefaultTemplateInfo.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Health.Fhir.TemplateManagement.Models
             { "microsofthealth/fhirconverter:default", new DefaultTemplateInfo(DataType.Hl7v2, "microsofthealth/fhirconverter:default", "Hl7v2DefaultTemplates.tar.gz") },
             { "microsofthealth/hl7v2templates:default", new DefaultTemplateInfo(DataType.Hl7v2, "microsofthealth/hl7v2templates:default", "Hl7v2DefaultTemplates.tar.gz") },
             { "microsofthealth/ccdatemplates:default", new DefaultTemplateInfo(DataType.Ccda, "microsofthealth/ccdatemplates:default", "CcdaDefaultTemplates.tar.gz") },
+            { "microsofthealth/jsontemplates:default", new DefaultTemplateInfo(DataType.Json, "microsofthealth/jsontemplates:default", "JsonDefaultTemplates.tar.gz") },
         };
 
         public DataType DataType { get; set; }


### PR DESCRIPTION
By discussion, we are going to pack the sample templates as default templates for JSON converter. This PR (1) packs the templates and (2) updates the version in release pipeline.