### PR TITLE
Suppress expected SHA1 hash

### DIFF
--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/StringFilters.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/StringFilters.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
         public static string Sha1Hash(string data)
         {
 #pragma warning disable CA5350
-            using var sha1 = new SHA1Managed();
+            using var sha1 = new SHA1Managed(); // lgtm[cs/weak-crypto]
 #pragma warning restore CA5350
             var hash = sha1.ComputeHash(Encoding.UTF8.GetBytes(data));
             return string.Concat(hash.Select(b => b.ToString("x2")));


### PR DESCRIPTION
Suppress expected SHA1 hash in lgtm analysis tool.

Ref: https://onees.lgtm.microsoft.com/help/lgtm/alert-suppression
Status after the update (no alert): https://onees.lgtm.microsoft.com/projects/u/gh/microsoft%2Ffhir-converter%2Ftree%2Fpersonal%2Fboywu%2Flgtm?mode=list