### PR TITLE
Fix down the smallest version of handlebars, upgrade defective packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "express": "^4.16.4",
     "fhir": "^4.7.9",
     "fs-extra": "^8.1.0",
-    "handlebars": "^4.7.7",
+    "handlebars": ">= 4.7.7",
     "lodash": "^4.17.21",
     "memory-cache": "^0.2.0",
     "ncp": "^2.0.0",


### PR DESCRIPTION
* For the [handlebars](https://www.npmjs.com/package/handlebars) package, we use a more specific way to declare the version number;
* For the [ajv](https://www.npmjs.com/package/ajv) package, currently we don't upgrade it since:
    * The most elegant way to do that is to use the `overrides` property, which is available from NPM [version 8.3](https://github.com/npm/cli/releases/tag/v8.3.0)
    * We don't want to restrict the version of NPM, especially such a new version
    * The `ajv` is actually indirectly referenced by `eslint` and `nodegit`, which we are actually not using in production environment