### PR TITLE
Turn on mac functional test check

### DIFF
--- a/release.yml
+++ b/release.yml
@@ -195,7 +195,7 @@ stages:
   
   - job: OSX_Functional_Test
     pool: CompassMacHosted
-    continueOnError: true
+    continueOnError: false
     steps:
     - checkout: none #skip checking out the default repository resource
     - task: DownloadBuildArtifacts@0


### PR DESCRIPTION
Turn on mac functional test check, so we don't have to look into it manually every time when the pipeline runs.