### PR TITLE
Remove invalid folder configuration in GeoPol file

### DIFF
--- a/GeoPol.xml
+++ b/GeoPol.xml
@@ -18,7 +18,6 @@
     <!-- Use back slash \ to indicate folder path e.g. src\external\ -->
     <ExcludeFolder>.gitignore</ExcludeFolder>
     <ExcludeFolder>GeoPol.xml</ExcludeFolder>
-    <ExcludeFolder>test</ExcludeFolder>
     <!-- 3rd Party Libraries section below -->
   </Component>
 </GeoPol_Folders>


### PR DESCRIPTION
Remove the `test` folder in path to exclude since it no longer exists in this repo.