### PR TITLE
Remove StyleCop from Nuspec

### DIFF
--- a/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.Liquid.Converter.nuspec
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.Liquid.Converter.nuspec
@@ -16,13 +16,12 @@
         <dependency id="Microsoft.IdentityModel.Protocols" version="6.8.0" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Azure.ContainerRegistry" version="1.0.0-preview.1" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Build" version="16.7.0" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Extensions.Caching.Memory" version="3.1.9" exclude="Build,Analyzers" />       
+        <dependency id="Microsoft.Extensions.Caching.Memory" version="3.1.9" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging" version="3.1.9" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="3.1.9" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Options" version="5.0.0" exclude="Build,Analyzers" />
         <dependency id="Newtonsoft.Json" version="13.0.1" exclude="Build,Analyzers" />
         <dependency id="SharpCompress" version="0.29.0" exclude="Build,Analyzers" />
-        <dependency id="StyleCop.Analyzers" version="1.1.118" exclude="Build,Analyzers" />
         <dependency id="System.Runtime" version="4.3.1" exclude="Build,Analyzers" />
         <dependency id="System.Runtime.Caching" version="4.7.0" exclude="Build,Analyzers" />
       </group>


### PR DESCRIPTION
- Remove StyleCop from the nuspec to prevent forcing consumers to import StyleCop
- This is a continuation of the previous PR: https://github.com/microsoft/FHIR-Converter/pull/397
    - I had not realized there was also an explicit .nuspec file