### PR TITLE
JsonProcessor interface to convert JObject

### DIFF
--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Processors/ProcessorTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Processors/ProcessorTests.cs
@@ -11,6 +11,7 @@ using DotLiquid;
 using Microsoft.Health.Fhir.Liquid.Converter.Exceptions;
 using Microsoft.Health.Fhir.Liquid.Converter.Models;
 using Microsoft.Health.Fhir.Liquid.Converter.Processors;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Processors
@@ -20,6 +21,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Processors
         private static readonly string _hl7v2TestData;
         private static readonly string _ccdaTestData;
         private static readonly string _jsonTestData;
+        private static readonly string _jsonExpectData;
         private static readonly string _fhirStu3TestData;
         private static readonly ProcessorSettings _processorSettings;
 
@@ -28,6 +30,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Processors
             _hl7v2TestData = File.ReadAllText(Path.Join(TestConstants.SampleDataDirectory, "Hl7v2", "LRI_2.0-NG_CBC_Typ_Message.hl7"));
             _ccdaTestData = File.ReadAllText(Path.Join(TestConstants.SampleDataDirectory, "Ccda", "CCD.ccda"));
             _jsonTestData = File.ReadAllText(Path.Join(TestConstants.SampleDataDirectory, "Json", "ExamplePatient.json"));
+            _jsonExpectData = File.ReadAllText(Path.Join(TestConstants.ExpectedDirectory, "ExamplePatient.json"));
             _fhirStu3TestData = File.ReadAllText(Path.Join(TestConstants.SampleDataDirectory, "Stu3", "Patient.json"));
             _processorSettings = new ProcessorSettings();
         }
@@ -241,6 +244,16 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Processors
 
             exception = Assert.Throws<RenderException>(() => processor.Convert(data, "NestingTooDeepDiffTemplate", templateProvider));
             Assert.Contains("Nesting too deep", exception.Message);
+        }
+
+        [Fact]
+        public void GivenJObjectInput_WhenConvertWithJsonProcessor_CorrectResultShouldBeReturned()
+        {
+            var processor = new JsonProcessor(_processorSettings);
+            var templateProvider = new TemplateProvider(TestConstants.JsonTemplateDirectory, DataType.Json);
+            var testData = JObject.Parse(_jsonTestData);
+            var result = processor.Convert(testData, "ExamplePatient", templateProvider);
+            Assert.True(JToken.DeepEquals(JObject.Parse(_jsonExpectData), JToken.Parse(result)));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/TestData/Expected/ExamplePatient.json
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/TestData/Expected/ExamplePatient.json
@@ -1,0 +1,44 @@
+﻿{
+  "resourceType": "Patient",
+  "id": "e8b835f7-0c46-4166-22ad-23e6783aaf54",
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MR"
+          }
+        ]
+      },
+      "system": "urn:oid:2.16.840.1.113883.19.5",
+      "value": "M0R1N2"
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "family": "Smith",
+      "given": [
+        "Jerry"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "1234-5678"
+    },
+    {
+      "system": "phone",
+      "value": "1234-5679"
+    }
+  ],
+  "gender": "male",
+  "birthDate": "2001-01-10",
+  "managingOrganization": {
+    "reference": "Organization/2.16.840.1.113883.19.5",
+    "display": "Good Health Clinic"
+  }
+}

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Parsers/JsonDataParser.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Parsers/JsonDataParser.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using Microsoft.Health.Fhir.Liquid.Converter.Exceptions;
 using Microsoft.Health.Fhir.Liquid.Converter.Extensions;
 using Microsoft.Health.Fhir.Liquid.Converter.Models;

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/JsonProcessor.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/JsonProcessor.cs
@@ -6,9 +6,11 @@
 using System.Collections.Generic;
 using System.Globalization;
 using DotLiquid;
+using Microsoft.Health.Fhir.Liquid.Converter.Extensions;
 using Microsoft.Health.Fhir.Liquid.Converter.Models;
 using Microsoft.Health.Fhir.Liquid.Converter.Models.Json;
 using Microsoft.Health.Fhir.Liquid.Converter.Parsers;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Schema;
 
 namespace Microsoft.Health.Fhir.Liquid.Converter.Processors
@@ -25,6 +27,12 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Processors
         public override string Convert(string data, string rootTemplate, ITemplateProvider templateProvider, TraceInfo traceInfo = null)
         {
             var jsonData = _parser.Parse(data);
+            return Convert(jsonData, rootTemplate, templateProvider, traceInfo);
+        }
+
+        public string Convert(JObject data, string rootTemplate, ITemplateProvider templateProvider, TraceInfo traceInfo = null)
+        {
+            var jsonData = data.ToObject();
             return Convert(jsonData, rootTemplate, templateProvider, traceInfo);
         }
 


### PR DESCRIPTION
Add interface in ```JsonProcessor``` to directly convert ```JObject``` instance.
The target is to decrease the serialization count to improve the performance in Synapse pipeline.