### PR TITLE
Add NJsonSchema dependency to nuspec file

### DIFF
--- a/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.Liquid.Converter.nuspec
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.Liquid.Converter.nuspec
@@ -21,6 +21,7 @@
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="3.1.9" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Options" version="5.0.0" exclude="Build,Analyzers" />
         <dependency id="Newtonsoft.Json" version="13.0.1" exclude="Build,Analyzers" />
+        <dependency id="NJsonSchema" version="10.7.2" exclude="Build,Analyzers" />
         <dependency id="SharpCompress" version="0.29.0" exclude="Build,Analyzers" />
         <dependency id="System.Runtime" version="4.3.1" exclude="Build,Analyzers" />
         <dependency id="System.Runtime.Caching" version="4.7.0" exclude="Build,Analyzers" />


### PR DESCRIPTION
The released Nuget package misses ```NJsonSchema``` dependency, add it to Nuspec file.