### PR TITLE
Fix empty path issue

### DIFF
--- a/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/ConverterLogicHandler.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.Tool/ConverterLogicHandler.cs
@@ -131,7 +131,10 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Tool
         private static void SaveConverterResult(string outputFilePath, ConverterResult result)
         {
             var outputFileDirectory = Path.GetDirectoryName(outputFilePath);
-            Directory.CreateDirectory(outputFileDirectory);
+            if (!string.IsNullOrEmpty(outputFileDirectory))
+            {
+                Directory.CreateDirectory(outputFileDirectory);
+            }
 
             var content = JsonConvert.SerializeObject(result, Formatting.Indented, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
             File.WriteAllText(outputFilePath, content);


### PR DESCRIPTION
When output file has no directory present like "1.txt", the tool will throw exception that it cannot create an empty directory.