### PR TITLE
fixed #458

### DIFF
--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/FiltersRenderingTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/FiltersRenderingTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.FilterTests
 {{ 'foo' | contains: 'fo' }}
 {{ '\E' | escape_special_chars }}
 {{ '\\E' | unescape_special_chars }}
-{{ true | is_nan }}
+{{ 1 | is_nan }}
 {{ -2019.6 | abs }}
 {{ 3 | pow: 3 }}
 {{ -5 | sign }}
@@ -28,7 +28,7 @@ f
 true
 \\E
 \E
-true
+false
 2019.6
 27
 -1

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/MathFiltersTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/MathFiltersTests.cs
@@ -13,10 +13,10 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.FilterTests
         [Fact]
         public void IsNaNTest()
         {
-            Assert.True(Filters.IsNaN("2019.6"));
-            Assert.False(Filters.IsNaN(true));
-            Assert.False(Filters.IsNaN(string.Empty));
-            Assert.False(Filters.IsNaN(new Hl7v2Data()));
+            Assert.False(Filters.IsNan("2019.6"));
+            Assert.True(Filters.IsNan(true));
+            Assert.True(Filters.IsNan(string.Empty));
+            Assert.True(Filters.IsNan(new Hl7v2Data()));
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/MathFilters.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/MathFilters.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
     {
         private static readonly Random RandomGenerator = new Random();
 
-        public static bool IsNaN(object data)
+        public static bool IsNan(object data)
         {
-            return double.TryParse(Convert.ToString(data, CultureInfo.InvariantCulture), NumberStyles.Any, NumberFormatInfo.InvariantInfo, out _);
+            return !double.TryParse(Convert.ToString(data, CultureInfo.InvariantCulture), NumberStyles.Any, NumberFormatInfo.InvariantInfo, out _);
         }
 
         public static double Abs(double data)


### PR DESCRIPTION
Addressed issues in #458

Adjusted name of IsNan MathFilter so that it can be used as 'is_nan' in liquid templates.

Fixed logic for IsNan filter as it was returning the opposite of what it was supposed to.