### PR TITLE
Change default to not log the input message in any post-processing exceptions

### DIFF
--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Models/ProcessorSettings.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Models/ProcessorSettings.cs
@@ -12,5 +12,8 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Models
 
         // Max iterations for rendering templates.
         public int MaxIterations { get; set; } = 100000;
+
+        // Boolean that determines whether the input message payload is included in the exception details
+        public bool IncludeInputInException { get; set; } = false;
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/OutputProcessors/JsonParserErrorListener.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/OutputProcessors/JsonParserErrorListener.cs
@@ -10,9 +10,23 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.OutputProcessors
 {
     public class JsonParserErrorListener : BaseErrorListener
     {
+        private bool _includeMessage = false;
+
+        public JsonParserErrorListener(bool includeMessage = false)
+        {
+            _includeMessage = includeMessage;
+        }
+
         public override void SyntaxError(TextWriter output, IRecognizer recognizer, IToken offendingSymbol, int line, int charPositionInLine, string msg, RecognitionException e)
         {
-            output.WriteLine("line " + line + ":" + charPositionInLine + " " + msg);
+            var syntaxError = "line " + line + ":" + charPositionInLine;
+
+            if (_includeMessage)
+            {
+                syntaxError = syntaxError + " message: " + msg;
+            }
+
+            output.WriteLine(syntaxError);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/BaseProcessor.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/BaseProcessor.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Processors
             var dictionary = new Dictionary<string, object> { { DataKey, data } };
             var context = CreateContext(templateProvider, dictionary);
             var rawResult = RenderTemplates(template, context);
-            var result = PostProcessor.Process(rawResult);
+            var result = PostProcessor.Process(rawResult, Settings);
             CreateTraceInfo(data, context, traceInfo);
 
             return result.ToString(Formatting.Indented);


### PR DESCRIPTION
If any exceptions occur during post processing, the current state is that the input message is included by default in the exception. Since the input message can contain sensitive information, we should instead not log this information by default, even though it is useful for troubleshooting. This PR changes the default behavior such that the input message is no longer logged with the post-processing exception.