### PR TITLE
fix: Template collection parsed should be empty when no blob templates provided.

### DIFF
--- a/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/Providers/BlobTemplateProviderTests.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/Providers/BlobTemplateProviderTests.cs
@@ -29,7 +29,6 @@ namespace Microsoft.Health.Fhir.TemplateManagement.UnitTests.Providers
 
             var templateCollection = await blobTemplateProvider.GetTemplateCollectionAsync();
 
-            Assert.NotEmpty(templateCollection);
             Assert.Single(templateCollection);
             Assert.Equal(templateCount, templateCollection[0].Count);
         }

--- a/src/Microsoft.Health.Fhir.TemplateManagement/ArtifactProviders/BlobTemplateProvider.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/ArtifactProviders/BlobTemplateProvider.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
@@ -63,7 +64,12 @@ namespace Microsoft.Health.Fhir.TemplateManagement.ArtifactProviders
 
             var parsedtemplates = TemplateUtility.ParseTemplates(templates);
 
-            var templateCollection = new List<Dictionary<string, Template>> { parsedtemplates };
+            var templateCollection = new List<Dictionary<string, Template>>();
+
+            if (parsedtemplates.Any())
+            {
+                templateCollection.Add(parsedtemplates);
+            }
 
             _templateCache.Set(_blobTemplateCacheKey, templateCollection, _templateCollectionConfiguration.ShortCacheTimeSpan);
 


### PR DESCRIPTION
Bug: When no templates are provided, template collection returned is not empty but a list containing an empty dictionary item.
Fix: If no templates are parsed, the template collection returned should be empty.