### PR TITLE
Update nuget config to single feed

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -6,7 +6,6 @@
 	<packageSources>
 		<!-- When <clear /> is present, previously defined sources are ignored -->
 		<clear />
-		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
 		<add key="Microsoft Health OSS" value="https://microsofthealthoss.pkgs.visualstudio.com/FhirServer/_packaging/Public/nuget/v3/index.json" />
 	</packageSources>
 	<activePackageSource>


### PR DESCRIPTION
Update nuget config to single feed for secure supply chain. 
Remove nuget.org feed since it is included in the Microsoft Health OSS feed.