### PR TITLE
Create filter to format time with a colon

### DIFF
--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/DateFiltersTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/DateFiltersTests.cs
@@ -220,6 +220,22 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.FilterTests
             yield return new object[] { @"2001-01T" };
         }
 
+        public static IEnumerable<object[]> GetValidDataForTimeHandling()
+        {
+            yield return new object[] { @"0730", "07:30:00" };
+            yield return new object[] { @"1730", "17:30:00" };
+            yield return new object[] { @"18:45", "18:45" };
+            yield return new object[] { @"09:45:50", "09:45:50" };
+            yield return new object[] { @"1", "1" };
+            yield return new object[] { @"abc", "abc" };
+            yield return new object[] { null, null };
+        }
+
+        public static IEnumerable<object[]> GetInvalidDataForTimeHandling()
+        {
+            yield return new object[] { @"9999" };
+        }
+
         [Theory]
         [MemberData(nameof(GetValidDataForAddSeconds))]
         public void GivenSeconds_WhenAddOnValidDateTime_CorrectDateTimeStringShouldBeReturned(string originalDateTime, double seconds, string timeZoneHandling, string expectedDateTime)
@@ -353,6 +369,22 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.FilterTests
         public void GivenAnInvalidDateTime_WhenFormatAsHl7DateTime_ExceptionShouldBeThrown(string input)
         {
             var exception = Assert.Throws<RenderException>(() => Filters.FormatAsHl7v2DateTime(input));
+            Assert.Equal(FhirConverterErrorCode.InvalidDateTimeFormat, exception.FhirConverterErrorCode);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetValidDataForTimeHandling))]
+        public void GivenAValidData_WhenFormatTimeWithColon_FormattedTimeOrOriginalInputShouldBeReturned(string input, string expectedDateTime)
+        {
+            var result = Filters.FormatTimeWithColon(input);
+            Assert.Equal(expectedDateTime, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetInvalidDataForTimeHandling))]
+        public void GivenInvalidData_WhenFormatAsTimeInterval_InputTimeShouldBeReturnedAndNoExceptionThrown(string input)
+        {
+            var exception = Assert.Throws<RenderException>(() => Filters.FormatTimeWithColon(input));
             Assert.Equal(FhirConverterErrorCode.InvalidDateTimeFormat, exception.FhirConverterErrorCode);
         }
 


### PR DESCRIPTION
In this issue: https://github.com/microsoft/FHIR-Converter/issues/513 it was reported that the time being returned by a HL7v2 to FHIR liquid template was not in the correct format.

The input time from the HL7v2 message was "0730" and the template was returning a FHIR resource with a time value of "0730". This is technically not a valid time value for FHIR. The [FHIR spec](https://build.fhir.org/datatypes.html#time) states that the format should be in HH:mm:ss format, so the templates technically should be updated to return "07:30:00" in this specific case and in other locations where HL7v2 - 2.8.35.2 Explicit time interval (ST) is used.

In this PR we are creating a new filter which can be used to format the time in the various places where the templates should be formatting the time.

The most common place is in the `timeOfDay` FHIR element like in this case of ServiceRequest: https://github.com/microsoft/FHIR-Converter/blob/370f5c1964c6e317ba406dad1b057b4399187b92/data/Templates/Hl7v2/Resource/_ServiceRequest.liquid#L533C1-L534C1

Currently the liquid template passes the value from the HL7v2 message to the FHIR output without any formatting. But after this new time formatting filter is rolled out then the templates could be updated to use the filter to format the time correctly.

The templates could be updated as follows to add the formatting filter `format_time_with_colon`

```
	{% if type_msg == "ORM" -%}
		{% assign obr_27_2_2_repetitions = OBR_child.27.2.2 | split: "," %}
		{% for entry in obr_27_2_2_repetitions %}
		  "{{ entry | format_time_with_colon }}",
		{% endfor %}
	{% endif -%}
```
