### PR TITLE
Add ConvertProcessorFactory

### DIFF
--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Factories/ConvertProcessorFactory.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Factories/ConvertProcessorFactory.cs
@@ -1,0 +1,58 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.Fhir.Liquid.Converter.Models;
+using Microsoft.Health.Fhir.Liquid.Converter.Processors;
+
+namespace Microsoft.Health.Fhir.Liquid.Converter.Factories
+{
+    public class ConvertProcessorFactory : IConvertProcessorFactory
+    {
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly ConvertTelemetryConfiguration _convertTelemetryConfiguration;
+
+        public ConvertProcessorFactory(ILoggerFactory loggerFactory, ConvertTelemetryConfiguration convertDataConfiguration)
+        {
+            _loggerFactory = EnsureArg.IsNotNull(loggerFactory, nameof(loggerFactory));
+            _convertTelemetryConfiguration = EnsureArg.IsNotNull(convertDataConfiguration, nameof(convertDataConfiguration));
+        }
+
+        public IFhirConverter GetProcessor(DataType inputDataType, ConvertDataOutputFormat outputFormat)
+        {
+            var processorSetting = new ProcessorSettings
+            {
+                EnableTelemetryLogger = _convertTelemetryConfiguration.EnableTelemetryLogger,
+            };
+
+            IFhirConverter converter;
+
+            switch (inputDataType, outputFormat)
+            {
+                case (DataType.Ccda, ConvertDataOutputFormat.Fhir):
+                    converter = new CcdaProcessor(processorSetting, _loggerFactory.CreateLogger<CcdaProcessor>());
+                    break;
+                case (DataType.Fhir, ConvertDataOutputFormat.Fhir):
+                    converter = new FhirProcessor(processorSetting, _loggerFactory.CreateLogger<FhirProcessor>());
+                    break;
+                case (DataType.Hl7v2, ConvertDataOutputFormat.Fhir):
+                    converter = new Hl7v2Processor(processorSetting, _loggerFactory.CreateLogger<Hl7v2Processor>());
+                    break;
+                case (DataType.Json, ConvertDataOutputFormat.Fhir):
+                    converter = new JsonProcessor(processorSetting, _loggerFactory.CreateLogger<JsonProcessor>());
+                    break;
+                case (DataType.Fhir, ConvertDataOutputFormat.Hl7v2):
+                    converter = new JsonToHl7v2Processor(processorSetting, _loggerFactory.CreateLogger<JsonToHl7v2Processor>());
+                    break;
+                default:
+                    throw new InvalidOperationException($"Input Data Type {inputDataType} and Output Format {outputFormat} pairing is not supported.");
+            }
+
+            return converter;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Factories/IConvertProcessorFactory.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Factories/IConvertProcessorFactory.cs
@@ -1,0 +1,15 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.Liquid.Converter.Models;
+using Microsoft.Health.Fhir.Liquid.Converter.Processors;
+
+namespace Microsoft.Health.Fhir.Liquid.Converter.Factories
+{
+    public interface IConvertProcessorFactory
+    {
+        public IFhirConverter GetProcessor(DataType inputDataType, ConvertDataOutputFormat outputFormat);
+    }
+}

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Models/ConvertDataOutputFormat.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Models/ConvertDataOutputFormat.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Models/ConvertDataOutputFormat.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Models/ConvertDataOutputFormat.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Health.Fhir.Liquid.Converter.Models
+{
+    public enum ConvertDataOutputFormat
+    {
+        Hl7v2,
+        Fhir,
+    }
+}

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Models/ConvertTelemetryConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Models/ConvertTelemetryConfiguration.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Health.Fhir.Liquid.Converter.Models
+{
+    public class ConvertTelemetryConfiguration
+    {
+        /// <summary>
+        /// Enable the performance telemetry logging.
+        /// </summary>
+        public bool EnableTelemetryLogger { get; set; } = false;
+    }
+}

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Models/ConvertTelemetryConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Models/ConvertTelemetryConfiguration.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
 
 namespace Microsoft.Health.Fhir.Liquid.Converter.Models
 {


### PR DESCRIPTION
Adds ConvertProcessFactory to return the correct implementation of IFhirConverter depending on the input and output dataTypes.