### PR TITLE
fix: remove duplicate meta section from _Patient

### DIFF
--- a/data/Templates/Hl7v2/Resource/_Patient.liquid
+++ b/data/Templates/Hl7v2/Resource/_Patient.liquid
@@ -198,6 +198,7 @@ Patient_ManagingOrganization_ID: A resource Id, used to fill "managingOrganizati
         ],
         "meta":
         {
+            "lastUpdated":"{{ PID.33.Value | format_as_date_time }}",
             "security":
             [
                 {% if ARV.2 %}
@@ -453,10 +454,6 @@ Patient_ManagingOrganization_ID: A resource Id, used to fill "managingOrganizati
                 {% endif -%}
             {% endunless -%}
         {% endunless -%}
-        "meta":
-        {
-            "lastUpdated":"{{ PID.33.Value | format_as_date_time }}",
-        },
         {% if PD1.16.1 -%}
             "active":{{ PD1.16.1.Value | get_property: 'CodeSystem/RegistryStatus', 'code' }},
         {% endif -%}


### PR DESCRIPTION
The `_Patient.liquid` template includes two `meta` sections. This PR combines the two sections.