### PR TITLE
Decouple the Nuget packages.

### DIFF
--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Microsoft.Health.Fhir.Liquid.Converter.csproj
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Microsoft.Health.Fhir.Liquid.Converter.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.TemplateManagement.csproj
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Microsoft.Health.Fhir.TemplateManagement.csproj
@@ -4,7 +4,6 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>true</IsPackable>
-    <NuspecFile>Microsoft.Health.Fhir.Liquid.Converter.nuspec</NuspecFile>
     <OrasVersion>0.12.0</OrasVersion>
     <OrasWinTarGzFile>oras_win_amd64.tar.gz</OrasWinTarGzFile>
     <OrasOSXTarGzFile>oras_osx_amd64.tar.gz</OrasOSXTarGzFile>


### PR DESCRIPTION
Currently we use .nuspec to define the nuget packaging manifest for the TemplateManagement project. it's also rename the nuget package to Converter. It's error-prone when we are making code changes especially with dependency update. 

We have decided to decouple the two packages into separate nuget packages. 