### PR TITLE
Use default template provider if containerUrl is empty

### DIFF
--- a/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/Factory/ConvertDataTemplateCollectionProviderFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement.UnitTests/Factory/ConvertDataTemplateCollectionProviderFactoryTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Health.Fhir.TemplateManagement.UnitTests.Factory
         }
 
         [Fact]
-        public void GivenInvalidStorageAccountConfiguration_WhenCreateTemplateCollectionProvider_ThenExceptionThrown()
+        public void GivenEmptyStorageAccountConfiguration_WhenCreateTemplateCollectionProvider_ThenDefaultTemplateProviderReturned()
         {
             var config = new TemplateCollectionConfiguration()
             {
@@ -64,8 +64,10 @@ namespace Microsoft.Health.Fhir.TemplateManagement.UnitTests.Factory
             var cache = new MemoryCache(new MemoryCacheOptions());
             var factory = new ConvertDataTemplateCollectionProviderFactory(cache, Options.Create(config));
 
-            // Null blob container url
-            Assert.Throws<ArgumentNullException>(() => factory.CreateTemplateCollectionProvider());
+            var templateCollectionProvider = factory.CreateTemplateCollectionProvider();
+
+            Assert.NotNull(templateCollectionProvider);
+            Assert.True(templateCollectionProvider is DefaultTemplateCollectionProvider);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.TemplateManagement/Factory/ConvertDataTemplateCollectionProviderFactory.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Factory/ConvertDataTemplateCollectionProviderFactory.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Fhir.TemplateManagement.Factory
         {
             var templateHostingConfiguration = _templateCollectionConfiguration.TemplateHostingConfiguration;
 
-            if (templateHostingConfiguration?.StorageAccountConfiguration != null)
+            if (templateHostingConfiguration?.StorageAccountConfiguration?.ContainerUrl != null)
             {
                 return CreateBlobTemplateCollectionProvider(templateHostingConfiguration.StorageAccountConfiguration);
             }


### PR DESCRIPTION
Currently, if containerUrl is empty, the factory attempts to create blob template provider and throws on null containerUrl. 
Instead it will be better to use default template provider and not throw on initialization.