### PR TITLE
Blob template collection size limit restriction

### DIFF
--- a/src/Microsoft.Health.Fhir.TemplateManagement/Configurations/StorageAccountConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Configurations/StorageAccountConfiguration.cs
@@ -1,8 +1,7 @@
-﻿// --------------------------------------------------------------------------
-// <copyright file="StorageAccountConfiguration.cs" company="Microsoft Corporation">
+﻿// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// </copyright>
-// --------------------------------------------------------------------------
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
 
 using System;
 

--- a/src/Microsoft.Health.Fhir.TemplateManagement/Configurations/TemplateHostingConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Configurations/TemplateHostingConfiguration.cs
@@ -1,8 +1,7 @@
-﻿// --------------------------------------------------------------------------
-// <copyright file="TemplateHostingConfiguration.cs" company="Microsoft Corporation">
+﻿// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// </copyright>
-// --------------------------------------------------------------------------
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
 
 namespace Microsoft.Health.Fhir.TemplateManagement.Configurations
 {

--- a/src/Microsoft.Health.Fhir.TemplateManagement/Exceptions/TemplateCollectionExceedsSizeLimitException.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Exceptions/TemplateCollectionExceedsSizeLimitException.cs
@@ -1,0 +1,23 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Fhir.TemplateManagement.Models;
+
+namespace Microsoft.Health.Fhir.TemplateManagement.Exceptions
+{
+    public class TemplateCollectionExceedsSizeLimitException : TemplateManagementException
+    {
+        public TemplateCollectionExceedsSizeLimitException(TemplateManagementErrorCode templateManagementErrorCode, string message)
+            : base(templateManagementErrorCode, message)
+        {
+        }
+
+        public TemplateCollectionExceedsSizeLimitException(TemplateManagementErrorCode templateManagementErrorCode, string message, Exception innerException)
+            : base(templateManagementErrorCode, message, innerException)
+        {
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.TemplateManagement/Models/TemplateManagementErrorCode.cs
+++ b/src/Microsoft.Health.Fhir.TemplateManagement/Models/TemplateManagementErrorCode.cs
@@ -29,8 +29,9 @@ namespace Microsoft.Health.Fhir.TemplateManagement.Models
         InvalidManifestInfo = 2601,
         InvalidBlobContent = 2602,
 
-        // ImageTooLargeException
+        // TemplateCollectionTooLargeException
         ImageSizeTooLarge = 2701,
+        BlobTemplateCollectionTooLarge = 2702,
 
         // ArtifactArchiveException
         DecompressArtifactFailed = 2801,


### PR DESCRIPTION
Check blob template collection is within the max size limit (10MB) to constrain template sizes.