### PR TITLE
Fix path returned for FHIR to HL7v2 default template errors

### DIFF
--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Processors/ConvertProcessorFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Processors/ConvertProcessorFactoryTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Processors
             yield return new object[] { DataType.Fhir, ConvertDataOutputFormat.Fhir, typeof(FhirProcessor) };
             yield return new object[] { DataType.Hl7v2, ConvertDataOutputFormat.Fhir, typeof(Hl7v2Processor) };
             yield return new object[] { DataType.Json, ConvertDataOutputFormat.Fhir, typeof(JsonProcessor) };
-            yield return new object[] { DataType.Fhir, ConvertDataOutputFormat.Hl7v2, typeof(JsonToHl7v2Processor) };
+            yield return new object[] { DataType.Fhir, ConvertDataOutputFormat.Hl7v2, typeof(FhirToHl7v2Processor) };
         }
 
         [Theory]

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Processors/ProcessorTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Processors/ProcessorTests.cs
@@ -368,9 +368,9 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Processors
         }
 
         [Fact]
-        public void GivenJObjectInput_WhenConvertWithJsonToHl7v2Processor_CorrectResultShouldBeReturned()
+        public void GivenJObjectInput_WhenConvertWithFhirToHl7v2Processor_CorrectResultShouldBeReturned()
         {
-            var processor = new JsonToHl7v2Processor(_processorSettings, FhirConverterLogging.CreateLogger<JsonToHl7v2Processor>());
+            var processor = new FhirToHl7v2Processor(_processorSettings, FhirConverterLogging.CreateLogger<FhirToHl7v2Processor>());
             var templateProvider = new TemplateProvider(TestConstants.TestTemplateDirectory, DataType.Json);
             var testData = JObject.Parse(_fhirBundleTestData);
             var result = processor.Convert(testData, "BundleToHl7v2", templateProvider);
@@ -378,9 +378,9 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Processors
         }
 
         [Fact]
-        public void GivenJObjectInput_WhenConvertWithJsonToHl7v2ProcessorWithInvalidTemplate_CorrectExceptionShouldBeThrown()
+        public void GivenJObjectInput_WhenConvertWithFhirToHl7v2ProcessorWithInvalidTemplate_CorrectExceptionShouldBeThrown()
         {
-            var processor = new JsonToHl7v2Processor(_processorSettings, FhirConverterLogging.CreateLogger<JsonToHl7v2Processor>());
+            var processor = new FhirToHl7v2Processor(_processorSettings, FhirConverterLogging.CreateLogger<FhirToHl7v2Processor>());
             var templateProvider = new TemplateProvider(TestConstants.TestTemplateDirectory, DataType.Json);
             var testData = JObject.Parse(_fhirBundleTestData);
             var exception = Assert.Throws<RenderException>(() => processor.Convert(testData, "BundleToHl7v2_MissingRequiredProperty", templateProvider));
@@ -388,9 +388,9 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Processors
         }
 
         [Fact]
-        public void GivenJObjectInput_WhenConvertWithJsonToHl7v2ProcessorWithInvalidMessageDefinitionSegment_CorrectExceptionShouldBeThrown()
+        public void GivenJObjectInput_WhenConvertWithFhirToHl7v2ProcessorWithInvalidMessageDefinitionSegment_CorrectExceptionShouldBeThrown()
         {
-            var processor = new JsonToHl7v2Processor(_processorSettings, FhirConverterLogging.CreateLogger<JsonToHl7v2Processor>());
+            var processor = new FhirToHl7v2Processor(_processorSettings, FhirConverterLogging.CreateLogger<FhirToHl7v2Processor>());
             var templateProvider = new TemplateProvider(TestConstants.TestTemplateDirectory, DataType.Json);
             var testData = JObject.Parse(_fhirBundleTestData);
             var exception = Assert.Throws<RenderException>(() => processor.Convert(testData, "BundleToHl7v2_InvalidSegmentObject", templateProvider));
@@ -398,9 +398,9 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.UnitTests.Processors
         }
 
         [Fact]
-        public void GivenJObjectInput_WhenConvertWithJsonToHl7v2ProcessorWithInvalidFieldNumber_CorrectExceptionShouldBeThrown()
+        public void GivenJObjectInput_WhenConvertWithFhirToHl7v2ProcessorWithInvalidFieldNumber_CorrectExceptionShouldBeThrown()
         {
-            var processor = new JsonToHl7v2Processor(_processorSettings, FhirConverterLogging.CreateLogger<JsonToHl7v2Processor>());
+            var processor = new FhirToHl7v2Processor(_processorSettings, FhirConverterLogging.CreateLogger<FhirToHl7v2Processor>());
             var templateProvider = new TemplateProvider(TestConstants.TestTemplateDirectory, DataType.Json);
             var testData = JObject.Parse(_fhirBundleTestData);
             var exception = Assert.Throws<RenderException>(() => processor.Convert(testData, "BundleToHl7v2_InvalidFieldNumber", templateProvider));

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/ConvertProcessorFactory.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/ConvertProcessorFactory.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Processors
                     converter = new JsonProcessor(processorSettings, _loggerFactory.CreateLogger<JsonProcessor>());
                     break;
                 case (DataType.Fhir, ConvertDataOutputFormat.Hl7v2):
-                    converter = new JsonToHl7v2Processor(processorSettings, _loggerFactory.CreateLogger<JsonToHl7v2Processor>());
+                    converter = new FhirToHl7v2Processor(processorSettings, _loggerFactory.CreateLogger<FhirToHl7v2Processor>());
                     break;
                 default:
                     throw new InvalidOperationException($"Input Data Type {inputDataType} and Output Format {outputFormat} pairing is not supported.");

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/FhirToHl7v2Processor.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/FhirToHl7v2Processor.cs
@@ -23,16 +23,18 @@ using NJsonSchema;
 
 namespace Microsoft.Health.Fhir.Liquid.Converter.Processors
 {
-    public class JsonToHl7v2Processor : BaseProcessor
+    public class FhirToHl7v2Processor : BaseProcessor
     {
         private readonly IDataParser _parser = new JsonDataParser();
 
         private string[] _segmentsWithFieldSeparator = new string[] { "MSH", "BHS", "FHS" };
 
-        public JsonToHl7v2Processor(ProcessorSettings processorSettings, ILogger<JsonToHl7v2Processor> logger)
+        public FhirToHl7v2Processor(ProcessorSettings processorSettings, ILogger<FhirToHl7v2Processor> logger)
             : base(processorSettings, logger)
         {
         }
+
+        protected override DataType DataType { get; set; } = DataType.Fhir;
 
         protected override string InternalConvert(string data, string rootTemplate, ITemplateProvider templateProvider, TraceInfo traceInfo = null)
         {


### PR DESCRIPTION
Previously when a default template did not exist the code was returning the default path of "Hl7v2/<templateName>" when converting from FHIR to HL7v2. The path should be "Fhir/<templateName>" so the PR updates the path that is returned.