### PR TITLE
Disable shared key access for storage accounts

### DIFF
--- a/docs/deploy/Deploy-DependentResources.bicep
+++ b/docs/deploy/Deploy-DependentResources.bicep
@@ -76,7 +76,9 @@ resource templateStorageAccountCreated 'Microsoft.Storage/storageAccounts@2022-0
     name: 'Standard_LRS'
   }
   kind: 'StorageV2'
-  properties: {}
+  properties: {
+    allowSharedKeyAccess: false
+  }
 }
 
 resource templateStorageAccount 'Microsoft.Storage/storageAccounts/blobServices@2022-09-01' = if (deployTemplateStore) {


### PR DESCRIPTION
Disable shared key access for storage accounts.
https://learn.microsoft.com/en-us/azure/storage/common/shared-key-authorization-prevent?tabs=template.
MI is used to access storage accounts.