### PR TITLE
Remove date parsing when input value is string

### DIFF
--- a/data/Templates/Stu3ToR4/DetectedIssue.liquid
+++ b/data/Templates/Stu3ToR4/DetectedIssue.liquid
@@ -2,7 +2,7 @@
 {
   "contained" : [ {{msg.contained | to_array | batch_render : 'Resource', 'msg'}} ],
   "code" : {{msg.category | to_json_string | default : '""'}},
-  "identifiedDateTime" : "{{ msg.date | date: "yyyy-MM-ddTHH:mm:ss.fff%K" }}",
+  "identifiedDateTime" : "{{ msg.date }}",
   "date" : "",
   "category" : ""
 }

--- a/data/Templates/Stu3ToR4/Immunization.liquid
+++ b/data/Templates/Stu3ToR4/Immunization.liquid
@@ -15,7 +15,7 @@
     },
     {% endif -%}
   ],
-  "occurrenceDateTime" : "{{ msg.date | date: "yyyy-MM-ddTHH:mm:ss.fff%K" }}",
+  "occurrenceDateTime" : "{{ msg.date }}",
   "performer" : [ {{ msg.practitioner | to_array | batch_render: 'Immunization/Practitioner', 'msg' }} ],
   "reasonCode" : {{msg.explanation.reason | to_json_string | default : '""'}},
   "reasonCode" : {{msg.explanation.reasonNotGiven | to_json_string | default : '""'}},


### PR DESCRIPTION
#562 causes datetime values in the input to be treated as strings. This preserves the original data and allows it to be passed as-is to the Liquid engine. Previously the behavior created .Net dateTime objects which were then passed to the rendering engine. Functions such as `date` respond differently when presented with a `string` or `dateTime` object. This difference is causing the `date` function to convert the string to local datetime and is causing the unit test to fail.

This PR removes the use of  the `date` function from within the test template. Since the value is already a properly formatted datetime string (versus a .net datetime object) this function is no longer needed.