### PR TITLE
Better handling of a template data mismatch error case

### DIFF
--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/SegmentFiltersTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/SegmentFiltersTests.cs
@@ -46,7 +46,7 @@ RXA|0|1|20131112||88^influenza, unspecified formulation^CVX|999|||01^Historical 
             Assert.True(!segments.ContainsKey("PV1"));
 
             // Hl7v2Data and segment id content could not be null
-            Assert.Throws<FhirConverterException>(() => Filters.GetFirstSegments(null, "PID"));
+            Assert.Throws<TemplateLoadException>(() => Filters.GetFirstSegments(null, "PID"));
             Assert.Throws<NullReferenceException>(() => Filters.GetFirstSegments(new Hl7v2Data(), null));
         }
 

--- a/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/SegmentFiltersTests.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter.UnitTests/Filters/SegmentFiltersTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Health.Fhir.Liquid.Converter.Exceptions;
 using Microsoft.Health.Fhir.Liquid.Converter.Models.Hl7v2;
 using Microsoft.Health.Fhir.Liquid.Converter.Parsers;
 using Xunit;
@@ -45,7 +46,7 @@ RXA|0|1|20131112||88^influenza, unspecified formulation^CVX|999|||01^Historical 
             Assert.True(!segments.ContainsKey("PV1"));
 
             // Hl7v2Data and segment id content could not be null
-            Assert.Throws<NullReferenceException>(() => Filters.GetFirstSegments(null, "PID"));
+            Assert.Throws<FhirConverterException>(() => Filters.GetFirstSegments(null, "PID"));
             Assert.Throws<NullReferenceException>(() => Filters.GetFirstSegments(new Hl7v2Data(), null));
         }
 

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/SegmentFilters.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/SegmentFilters.cs
@@ -6,6 +6,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Health.Fhir.Liquid.Converter.Exceptions;
+using Microsoft.Health.Fhir.Liquid.Converter.Models;
 using Microsoft.Health.Fhir.Liquid.Converter.Models.Hl7v2;
 
 namespace Microsoft.Health.Fhir.Liquid.Converter
@@ -17,6 +19,11 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
     {
         public static Dictionary<string, Hl7v2Segment> GetFirstSegments(Hl7v2Data hl7v2Data, string segmentIdContent)
         {
+            if (hl7v2Data == null)
+            {
+                throw new FhirConverterException(FhirConverterErrorCode.TemplateDataMismatch, "Incorrect template was passed in for the input data format.");
+            }
+
             var result = new Dictionary<string, Hl7v2Segment>();
             var segmentIds = segmentIdContent.Split(@"|");
             for (var i = 0; i < hl7v2Data.Meta.Count; ++i)

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/SegmentFilters.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Filters/SegmentFilters.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter
         {
             if (hl7v2Data == null)
             {
-                throw new FhirConverterException(FhirConverterErrorCode.TemplateDataMismatch, "Incorrect template was passed in for the input data format.");
+                throw new TemplateLoadException(FhirConverterErrorCode.TemplateDataMismatch, "Incorrect template was passed in for the input data format.");
             }
 
             var result = new Dictionary<string, Hl7v2Segment>();

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Models/FhirConverterErrorCode.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Models/FhirConverterErrorCode.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Models
         InvalidCodeMapping = 1103,
         TemplateSyntaxError = 1104,
         InvalidJsonSchema = 1105,
+        TemplateDataMismatch = 1106,
 
         // DataParseException
         InputParsingError = 1201,

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/BaseProcessor.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/BaseProcessor.cs
@@ -159,6 +159,10 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Processors
             {
                 throw;
             }
+            catch (FhirConverterException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 throw new RenderException(FhirConverterErrorCode.TemplateRenderingError, string.Format(Resources.TemplateRenderingError, ex.Message), ex);

--- a/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/BaseProcessor.cs
+++ b/src/Microsoft.Health.Fhir.Liquid.Converter/Processors/BaseProcessor.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Health.Fhir.Liquid.Converter.Processors
             {
                 throw;
             }
-            catch (FhirConverterException)
+            catch (TemplateLoadException)
             {
                 throw;
             }


### PR DESCRIPTION
In this PR I handle a case where a template calls a Filter that expects hl7 data but what was passed in was fhir. So, in this case there is no hl7 passed in and it fails with a generic message (ie Internal server error with 500) in the convert. This change is needed so that in convert we can catch this specific case and respond with a better message. 