### PR TITLE
Fix: Correct obrSegmentPositionIndex_orc increment to ensure proper ORC parent detection in ORU_R01.liquid

### DIFF
--- a/data/Templates/Hl7v2/ORU_R01.liquid
+++ b/data/Templates/Hl7v2/ORU_R01.liquid
@@ -1854,8 +1854,8 @@
                     {%- comment -%} SPECIMEN_OBSERVATION - PRT related coding start {%- endcomment -%} 
                 {% endfor -%}
                 {% assign obxSegmentPositionIndex_obr = obxSegmentPositionIndex_obr | plus: 1 -%}  
-            {% assign obrSegmentPositionIndex_orc = obrSegmentPositionIndex_orc | plus: 1 -%} 
-        {% endfor -%}
-    {% endfor -%}
+			{% endfor -%}
+			{% assign obrSegmentPositionIndex_orc = obrSegmentPositionIndex_orc | plus: 1 -%} 
+		{% endfor -%}
     ] 
 }


### PR DESCRIPTION
Fixes #605

This change ensures that `obrSegmentPositionIndex_orc` is incremented correctly inside the OBR loop rather than the OBX loop.  
Previously, `checkParent` always referenced the first ORC segment depending on message structure, instead of the actual ORC parent of the current OBR.  
By adjusting the position index logic, the correct ORC-OBR relationship is now maintained.
