### PR TITLE
fix: remove redundant physicalType field

### DIFF
--- a/data/Templates/Hl7v2/DataType/_PL_HDLocation.liquid
+++ b/data/Templates/Hl7v2/DataType/_PL_HDLocation.liquid
@@ -20,15 +20,4 @@
         },
     ],
     {% endif -%}
-    "physicalType":
-    {
-        "coding":
-        [
-            {
-                    "code":"si",
-                    "display":"site",
-                    "system":"http://terminology.hl7.org/CodeSystem/location-physical-type",
-            },
-        ],
-    },
 {% endif -%}


### PR DESCRIPTION
During the conversion of HL7 messages to FHIR resources, I found that the template DataType/PL_HDLocation defines the field physicalType, even though this property is already included in PLLocation. This duplication leads to physicalType being generated twice in the same resource (as an array).

Root Cause
PLLocation already includes physicalType.
When DataType/PL_HDLocation is rendered inside PLLocation, it introduces another physicalType.
The same applies when DataType/PL_HDLocation is called from NDLocation.

Fix
Removed the physicalType field from DataType/PL_HDLocation.

Impact
Prevents duplicate physicalType fields in FHIR resources.
Safe change: both PLLocation and NDLocation already handle physicalType.
No edge cases identified where DataType/PL_HDLocation requires its own physicalType.